### PR TITLE
update I420 buffer handling and stride calculations

### DIFF
--- a/src/dictionaries/node_webrtc/image_data.hh
+++ b/src/dictionaries/node_webrtc/image_data.hh
@@ -36,7 +36,7 @@ public:
   }
 
   [[nodiscard]] size_t sizeOfChromaPlane() const {
-    return sizeOfLuminancePlane() / 4;
+    return static_cast<size_t>((width() + 1) / 2) * static_cast<size_t>((height() + 1) / 2);
   }
 
   uint8_t *dataY() { return static_cast<uint8_t *>(data.contents.Data()); }
@@ -45,7 +45,7 @@ public:
 
   uint8_t *dataU() { return &dataY()[sizeOfLuminancePlane()]; }
 
-  [[nodiscard]] int strideU() const { return width() / 2; }
+  [[nodiscard]] int strideU() const { return (width() + 1) / 2; }
 
   uint8_t *dataV() { return &dataU()[sizeOfChromaPlane()]; }
 

--- a/src/dictionaries/webrtc/video_frame_buffer.cc
+++ b/src/dictionaries/webrtc/video_frame_buffer.cc
@@ -1,5 +1,6 @@
 #include "src/dictionaries/webrtc/video_frame_buffer.hh"
 
+#include <libyuv.h>
 #include <webrtc/api/video/i420_buffer.h>
 
 #include "src/dictionaries/node_webrtc/image_data.hh"
@@ -40,18 +41,19 @@ TO_NAPI_IMPL(const webrtc::I420BufferInterface *, pair) {
   Napi::EscapableHandleScope scope(env);
   auto value = pair.second;
 
-  auto sizeOfSrcYPlane = value->StrideY() * value->height();
-  auto sizeOfSrcUPlane = value->StrideU() * value->height() / 2;
-  auto sizeOfSrcVPlane = value->StrideV() * value->height() / 2;
-  auto sizeOfDstYPlane = value->width() * value->height();
-  auto sizeOfDstUPlane = sizeOfDstYPlane / 4;
-  auto sizeOfDstVPlane = sizeOfDstYPlane / 4;
+  auto dstYStride  = value->width();
+  auto dstUVStride = (value->width() + 1) / 2;
+  auto uvHeight     = (value->height() + 1) / 2;
 
+  auto sizeOfDstYPlane = dstYStride  * value->height();
+  auto sizeOfDstUPlane = dstUVStride * uvHeight;
+  auto sizeOfDstVPlane = dstUVStride * uvHeight;
+  
   auto byteLength = sizeOfDstYPlane + sizeOfDstUPlane + sizeOfDstVPlane;
   auto maybeArrayBuffer = Napi::ArrayBuffer::New(env, byteLength);
   if (maybeArrayBuffer.Env().IsExceptionPending()) {
     return Validation<Napi::Value>::Invalid(
-        maybeArrayBuffer.Env().GetAndClearPendingException().Message());
+      maybeArrayBuffer.Env().GetAndClearPendingException().Message());
   }
   auto data = static_cast<uint8_t *>(maybeArrayBuffer.Data());
 
@@ -63,29 +65,17 @@ TO_NAPI_IMPL(const webrtc::I420BufferInterface *, pair) {
   auto dstUPlane = data + sizeOfDstYPlane;
   auto dstVPlane = dstUPlane + sizeOfDstUPlane;
 
-  if (sizeOfSrcYPlane == sizeOfDstYPlane) {
-    memcpy(dstYPlane, srcYPlane, sizeOfDstYPlane);
-  } else {
-    for (int i = 0, j = 0; i < sizeOfSrcYPlane;
-         i += value->StrideY(), j += value->width()) {
-      memcpy(dstYPlane + j, srcYPlane + i, value->width());
-    }
-  }
-  if (sizeOfSrcUPlane == sizeOfDstUPlane) {
-    memcpy(dstUPlane, srcUPlane, sizeOfDstUPlane);
-  } else {
-    for (int i = 0, j = 0; i < sizeOfSrcUPlane;
-         i += value->StrideU(), j += value->width() / 2) {
-      memcpy(dstUPlane + j, srcUPlane + i, value->width() / 2);
-    }
-  }
-  if (sizeOfSrcVPlane == sizeOfDstVPlane) {
-    memcpy(dstVPlane, srcVPlane, sizeOfDstVPlane);
-  } else {
-    for (int i = 0, j = 0; i < sizeOfSrcVPlane;
-         i += value->StrideV(), j += value->width() / 2) {
-      memcpy(dstVPlane + j, srcVPlane + i, value->width() / 2);
-    }
+  int rc = libyuv::I420Copy(
+      srcYPlane, value->StrideY(),
+      srcUPlane, value->StrideU(),
+      srcVPlane, value->StrideV(),
+      dstYPlane, dstYStride,
+      dstUPlane, dstUVStride,
+      dstVPlane, dstUVStride,
+      value->width(), value->height());
+
+  if (rc != 0) {
+    return Validation<Napi::Value>::Invalid("Failed to copy I420 buffer: " + std::to_string(rc));
   }
 
   // FIXME(mroberts): How to create a Uint8ClampedArray?

--- a/src/methods/i420_helpers.cc
+++ b/src/methods/i420_helpers.cc
@@ -25,8 +25,13 @@ Validation<RgbaImageData> ImageData::toRgba() const {
 }
 
 Validation<I420ImageData> I420ImageData::Create(ImageData imageData) {
-  auto expectedByteLength =
-      static_cast<size_t>(imageData.width * imageData.height * 1.5);
+  auto y = imageData.width;
+  auto u = (imageData.width + 1) / 2;
+  auto v = (imageData.width + 1) / 2;
+  auto h = imageData.height;
+
+  size_t expectedByteLength = static_cast<size_t>(y * h + (u + v) * ((h + 1) / 2));
+  
   auto actualByteLength = imageData.contents.ByteLength();
   if (actualByteLength != expectedByteLength) {
     auto error = "Expected a .byteLength of " +

--- a/test/i420helpers.js
+++ b/test/i420helpers.js
@@ -73,6 +73,73 @@ tape("rgbaToI420(rgbaFrame, i420Frame)", (t) => {
   });
 });
 
+tape("i420ToRgba(i420Frame, rgbaFrame) — odd size", (t) => {
+  t.test("it works", (t) => {
+    const width = 678;
+    const height = 381;
+
+    const i420Frame = new I420Frame(width, height);
+    const rgbaFrame = new RgbaFrame(width, height);
+
+    blackenI420Frame(i420Frame);
+    i420ToRgba(i420Frame, rgbaFrame);
+    t.ok(
+      everyRgba(rgbaFrame, [0, 0, 0, 255]),
+      "converting a black I420 frame to RGBA works on odd size",
+    );
+
+    whitenI420Frame(i420Frame);
+    i420ToRgba(i420Frame, rgbaFrame);
+    t.ok(
+      everyRgba(rgbaFrame, [255, 255, 255, 255]),
+      "converting a white I420 frame to RGBA works on odd size",
+    );
+
+    setYuv(i420Frame, [173, 143, 31]);
+    i420ToRgba(i420Frame, rgbaFrame);
+    t.ok(
+      everyRgba(rgbaFrame, [28, 255, 213, 255]),
+      "converting a turquoise I420 frame to RGBA works on odd size",
+    );
+
+    t.end();
+  });
+});
+
+tape("rgbaToI420(rgbaFrame, i420Frame) — odd size", (t) => {
+  t.test("it works", (t) => {
+    const width = 678;
+    const height = 381;
+
+    const rgbaFrame = new RgbaFrame(width, height);
+    const i420Frame = new I420Frame(width, height);
+
+    blackenRgbaFrame(rgbaFrame);
+    rgbaToI420(rgbaFrame, i420Frame);
+    t.ok(
+      everyYuv(i420Frame, [16, 128, 128]),
+      "converting a black RGBA frame to I420 works on odd size",
+    );
+
+    whitenRgbaFrame(rgbaFrame);
+    rgbaToI420(rgbaFrame, i420Frame);
+    t.ok(
+      everyYuv(i420Frame, [235, 128, 128]),
+      "converting a white RGBA frame to I420 works on odd size",
+    );
+
+    setRgba(rgbaFrame, [28, 255, 213, 255]);
+    rgbaToI420(rgbaFrame, i420Frame);
+    t.ok(
+      everyYuv(i420Frame, [173, 143, 31]) ||
+        everyYuv(i420Frame, [173, 143, 32]), // NOTE(jack): arm64 seems to have slightly different rounding for whatever reason? very strange
+      "converting a turquoise RGBA frame to I420 works on odd size",
+    );
+
+    t.end();
+  });
+});
+
 function setYuv(i420Frame, yuv) {
   for (let i = 0; i < i420Frame.byteLength; i++) {
     if (i < i420Frame.sizeOfLuminancePlane) {

--- a/test/lib/frame.js
+++ b/test/lib/frame.js
@@ -29,7 +29,9 @@ class I420Frame {
   }
 
   get sizeOfChromaPlane() {
-    return this.sizeOfLuminancePlane / 4;
+    const chromaWidth = Math.floor((this.width + 1) / 2);
+    const chromaHeight = Math.floor((this.height + 1) / 2);
+    return chromaWidth * chromaHeight;
   }
 }
 


### PR DESCRIPTION
# Refactor I420 buffer handling and stride calculations (odd resolution fix)

### Background

While using `node-webrtc` for WebRTC testing on an iPhone device, I encountered the following error:

```
TypeError: Expected a .byteLength of 387477, not 387476
    at VideoProcessor.processFrame (/app/src/service/VideoProcessor.ts:122:13)
    at /app/node_modules/@roamhq/wrtc/lib/eventtarget.js:43:18
    at Set.forEach (<anonymous>)
    at /app/node_modules/@roamhq/wrtc/lib/eventtarget.js:36:15
    at processTicksAndRejections (node:internal/process/task_queues:85:11)
[ERROR] 02:02:52 TypeError: Expected a .byteLength of 387477, not 387476
```

During debugging, I found that in some cases the frame dimensions included **odd values** such as `width = 678` and `height = 381`.
The current `node-webrtc` implementation did not properly account for odd resolutions in I420 buffer calculations.

---

### Changes

* **Odd resolution handling**

  * Updated I420 buffer size calculation to round up remainders when dimensions are odd.
  * Referenced WebKit’s libwebrtc implementation, which already includes proper handling:

    * [WebKit i010\_buffer.cc](https://github.com/WebKit/WebKit/blob/main/Source/ThirdParty/libwebrtc/Source/webrtc/api/video/i010_buffer.cc)

* **Stride calculation improvement**

  * Replaced manual branching logic with a libyuv function that provides stride calculation.
  * Since libyuv is already used elsewhere in the codebase, this improves consistency and maintainability.

    * [[libyuv convert.cc](https://github.com/WebKit/WebKit/blob/main/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/convert.cc)](https://github.com/WebKit/WebKit/blob/main/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/convert.cc)

---

### Expected Outcome

* Fixes `.byteLength mismatch` errors when processing frames with odd resolutions.
* Simplifies stride calculation logic and ensures consistency by leveraging libyuv functions.

---

### Notes

This is my **first open source contribution** 
If I missed any procedural steps or if there are improvements I should make in the PR process, please let me know.