### PR TITLE
remove RTCPeerConnection#readyState

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -166,11 +166,6 @@ function RTCPeerConnection() {
       },
       enumerable: true,
     },
-    readyState: {
-      get: function getReadyState() {
-        return pc.getReadyState();
-      },
-    },
     sctp: {
       get: function () {
         return pc.sctp;


### PR DESCRIPTION
As far as I can see, RTCPeerConnection does _not_ have this field, and there actually isn't a native `getReadyState()` method.

It looks like a leftover from an old cleanup, maybe [here](https://github.com/WonderInventions/node-webrtc/commit/36bae6e87f56128f3dfa82edf5932e45b2100b4b#diff-876bca3605f4d5c799e62a09d5fa98b2fb6399bc66499663a8699be6023eac5fL536).