### PR TITLE
Add Windows platform TLS verifier for TURN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,11 @@ macro(assign_bool var)
   endif()
 endmacro()
 
-assign_bool(use_custom_libcxx "TRUE")
+if (WIN32)
+  assign_bool(use_custom_libcxx "FALSE")
+else()
+  assign_bool(use_custom_libcxx "TRUE")
+endif()
 assign_bool(is_arm32 "y$ENV{TARGET_ARCH}" STREQUAL "yarm")
 assign_bool(is_arm64 "y$ENV{TARGET_ARCH}" STREQUAL "yarm64")
 
@@ -75,15 +79,18 @@ set(libc++_objects
   atomic${obj_ext}
   barrier${obj_ext}
   bind${obj_ext}
+  call_once${obj_ext}
   charconv${obj_ext}
   chrono${obj_ext}
   condition_variable${obj_ext}
   condition_variable_destructor${obj_ext}
   d2fixed${obj_ext}
   d2s${obj_ext}
+  directory_iterator${obj_ext}
+  error_category${obj_ext}
   exception${obj_ext}
   f2s${obj_ext}
-  format${obj_ext}
+  filesystem_error${obj_ext}
   functional${obj_ext}
   future${obj_ext}
   hash${obj_ext}
@@ -95,7 +102,10 @@ set(libc++_objects
   mutex${obj_ext}
   mutex_destructor${obj_ext}
   new${obj_ext}
-  optional${obj_ext}
+  new_handler${obj_ext}
+  new_helpers${obj_ext}
+  operations${obj_ext}
+  path${obj_ext}
   random${obj_ext}
   random_shuffle${obj_ext}
   regex${obj_ext}
@@ -106,21 +116,16 @@ set(libc++_objects
   system_error${obj_ext}
   thread${obj_ext}
   typeinfo${obj_ext}
-  utility${obj_ext}
   valarray${obj_ext}
-  variant${obj_ext}
   vector${obj_ext}
   verbose_abort${obj_ext}
 )
 
 if(WIN32)
   list(APPEND libc++_objects
-    legacy_debug_handler${obj_ext}
-    legacy_pointer_safety${obj_ext}
     locale_win32${obj_ext}
     support${obj_ext}
     thread_win32${obj_ext}
-    verbose_abort${obj_ext}
   )
 endif()
 
@@ -183,7 +188,12 @@ set_target_properties(libc++abi PROPERTIES IMPORTED_OBJECTS_DEBUG "${libc++abi_o
 # M106: branch-heads/5249
 # M110: branch-heads/5481
 # M114: branch-heads/5735
-set(WEBRTC_REVISION branch-heads/5735)
+set(DEFAULT_WEBRTC_REVISION branch-heads/5735)
+if(DEFINED ENV{WEBRTC_REVISION} AND NOT "$ENV{WEBRTC_REVISION}" STREQUAL "")
+  set(DEFAULT_WEBRTC_REVISION "$ENV{WEBRTC_REVISION}")
+endif()
+set(WEBRTC_REVISION "${DEFAULT_WEBRTC_REVISION}" CACHE STRING "libwebrtc branch/tag/ref to fetch")
+message(STATUS "Using WEBRTC_REVISION=${WEBRTC_REVISION}")
 
 file(STRINGS nix.gni NIX_GN_GEN_ARGS)
 list(APPEND GN_GEN_ARGS
@@ -246,11 +256,16 @@ else()
   endif()
 endif()
 
-if (WIN32)
+if (WIN32 AND ${use_custom_libcxx})
   set(byproducts
     ${libc++_objects}
     ${libwebrtc_binary_dir}/obj/webrtc.lib
     ${libwebrtc_binary_dir}/obj/api/libjingle_peerconnection_api.lib
+  )
+elseif(WIN32)
+  set(byproducts
+    ${libwebrtc_binary_dir}/obj/webrtc.lib
+    ${libwebrtc_binary_dir}/obj/api/create_peerconnection_factory.lib
   )
 else()
   set(byproducts
@@ -278,7 +293,7 @@ ExternalProject_Add(
 
   DOWNLOAD_COMMAND  ${CMAKE_COMMAND} -E env DEPOT_TOOLS=${depot_tools_install_dir} PLATFORM=${PLATFORM} WEBRTC_REVISION=${WEBRTC_REVISION} ${CMAKE_SOURCE_DIR}/scripts/download-webrtc.${suffix}
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env BINARY_DIR=<BINARY_DIR> DEPOT_TOOLS=${depot_tools_install_dir} GN_GEN_ARGS=${GN_GEN_ARGS} SOURCE_DIR=<SOURCE_DIR> ${CMAKE_SOURCE_DIR}/scripts/configure-webrtc.${suffix}
-  BUILD_COMMAND     ${CMAKE_COMMAND} -E env CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} DEPOT_TOOLS=${depot_tools_install_dir} ${CMAKE_SOURCE_DIR}/scripts/build-webrtc.${suffix}
+  BUILD_COMMAND     ${CMAKE_COMMAND} -E env CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} DEPOT_TOOLS=${depot_tools_install_dir} USE_CUSTOM_LIBCXX=${use_custom_libcxx} ${CMAKE_SOURCE_DIR}/scripts/build-webrtc.${suffix}
   INSTALL_COMMAND   ""
 )
 
@@ -303,23 +318,25 @@ add_library(libpeerconnection STATIC IMPORTED)
 add_dependencies(libpeerconnection project_libwebrtc)
 
 if(WIN32)
-  set_property(TARGET libpeerconnection PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/api/libjingle_peerconnection_api.lib")
+  set_property(TARGET libpeerconnection PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/api/create_peerconnection_factory.lib")
 else()
   set_property(TARGET libpeerconnection PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/api/libjingle_peerconnection_api.a")
 endif()
 
-# Video codec factories (audio factories are already in libwebrtc.a)
-add_library(libbuiltin_video_encoder_factory STATIC IMPORTED)
-add_dependencies(libbuiltin_video_encoder_factory project_libwebrtc)
-set_property(TARGET libbuiltin_video_encoder_factory PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/api/video_codecs/libbuiltin_video_encoder_factory.a")
+if(NOT WIN32)
+  # Video codec factories (audio factories are already in libwebrtc.a)
+  add_library(libbuiltin_video_encoder_factory STATIC IMPORTED)
+  add_dependencies(libbuiltin_video_encoder_factory project_libwebrtc)
+  set_property(TARGET libbuiltin_video_encoder_factory PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/api/video_codecs/libbuiltin_video_encoder_factory.a")
 
-add_library(libbuiltin_video_decoder_factory STATIC IMPORTED)
-add_dependencies(libbuiltin_video_decoder_factory project_libwebrtc)
-set_property(TARGET libbuiltin_video_decoder_factory PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/api/video_codecs/libbuiltin_video_decoder_factory.a")
+  add_library(libbuiltin_video_decoder_factory STATIC IMPORTED)
+  add_dependencies(libbuiltin_video_decoder_factory project_libwebrtc)
+  set_property(TARGET libbuiltin_video_decoder_factory PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/api/video_codecs/libbuiltin_video_decoder_factory.a")
 
-add_library(librtc_internal_video_codecs STATIC IMPORTED)
-add_dependencies(librtc_internal_video_codecs project_libwebrtc)
-set_property(TARGET librtc_internal_video_codecs PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/media/librtc_internal_video_codecs.a")
+  add_library(librtc_internal_video_codecs STATIC IMPORTED)
+  add_dependencies(librtc_internal_video_codecs project_libwebrtc)
+  set_property(TARGET librtc_internal_video_codecs PROPERTY IMPORTED_LOCATION "${libwebrtc_binary_dir}/obj/media/librtc_internal_video_codecs.a")
+endif()
 
 set(libc++_include_dir
   "${libwebrtc_source_dir}/src/buildtools/third_party/libc++/trunk/include"
@@ -400,11 +417,16 @@ target_link_libraries(${MODULE} PRIVATE
   ${CMAKE_THREAD_LIBS_INIT}
   libpeerconnection
   libwebrtc
-  libbuiltin_video_encoder_factory
-  libbuiltin_video_decoder_factory
-  librtc_internal_video_codecs
   ${CMAKE_JS_LIB}
 )
+
+if(NOT WIN32)
+  target_link_libraries(${MODULE} PRIVATE
+    libbuiltin_video_encoder_factory
+    libbuiltin_video_decoder_factory
+    librtc_internal_video_codecs
+  )
+endif()
 
 target_compile_definitions(${MODULE} PRIVATE
   -DNAPI_VERSION=3
@@ -416,7 +438,12 @@ if(WIN32)
     PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
   )
 
+  target_compile_options(${MODULE} PRIVATE
+    /FI${CMAKE_SOURCE_DIR}/src/webrtc_compat.hh
+  )
+
   target_link_libraries(${MODULE} PRIVATE
+    crypt32.lib
     dmoguids.lib
     msdmo.lib
     secur32.lib
@@ -430,6 +457,10 @@ if(WIN32)
   if (${use_custom_libcxx})
     target_include_directories(${MODULE} SYSTEM PRIVATE
       ${libc++_include_dir}
+    )
+
+    target_compile_options(${MODULE} PRIVATE
+      /clang:-nostdinc++
     )
 
     target_link_libraries(${MODULE} PRIVATE

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 
 [![NPM](https://img.shields.io/npm/v/@roamhq/wrtc.svg)](https://www.npmjs.com/package/@roamhq/wrtc)
 
-node-webrtc is a Node.js Native Addon that provides bindings to [WebRTC
-M106](https://webrtc.googlesource.com/src/+/branch-heads/5249). This project is
+node-webrtc is a Node.js Native Addon that provides bindings to libwebrtc. This project is
 aiming for spec-compliance and will eventually be tested using the W3C's
 [web-platform-tests](https://github.com/web-platform-tests/wpt) project. A
 number of [nonstandard APIs](docs/nonstandard-apis.md) for testing are also
 included.
+
+This fork defaults to `branch-heads/5735` and supports overriding the upstream
+libwebrtc ref at build time with `WEBRTC_REVISION=<ref>`.
 
 ## Install
 
@@ -23,6 +25,20 @@ architecture, based on optional dependency filters.
 
 To install a debug build or cross-compile, you should [build from
 source](docs/build-from-source.md).
+
+To experiment with a different upstream libwebrtc revision when debugging a
+native networking issue:
+
+```bash
+WEBRTC_REVISION=branch-heads/5735 npm run build
+```
+
+or on PowerShell:
+
+```powershell
+$env:WEBRTC_REVISION="branch-heads/5735"
+npm run build
+```
 
 ## Supported Platforms
 

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "make-prebuilt": "node scripts/make-prebuilt.js",
     "install-example": "node scripts/install-example.js",
     "lint": "eslint lib/*.js lib/**/*.js test/*.js test/**/*.js scripts/*.js",
-    "test": "node --expose-gc test/all.js",
-    "prepare": "husky"
+    "test": "node --expose-gc test/all.js"
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix",

--- a/scripts/build-from-source.js
+++ b/scripts/build-from-source.js
@@ -36,9 +36,18 @@ function main() {
   if (platform === "win32") {
     // Explicitly find the real rc.exe from the Windows SDK and pass it to
     // CMake, since cmake-js may still find the npm "rc" package otherwise.
-    const { stdout } = spawnSync("where", ["rc.exe"], { encoding: "utf-8" });
-    if (stdout) {
-      args.push(`--CDCMAKE_RC_COMPILER="${stdout.replace(/\\/g, "/")}"`);
+    const explicitRc = process.env.WRTC_RC_COMPILER;
+    if (explicitRc) {
+      args.push(`--CDCMAKE_RC_COMPILER="${explicitRc.replace(/\\/g, "/")}"`);
+    } else {
+      const { stdout } = spawnSync("where", ["rc.exe"], { encoding: "utf-8" });
+      const firstMatch = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean);
+      if (firstMatch) {
+        args.push(`--CDCMAKE_RC_COMPILER="${firstMatch.replace(/\\/g, "/")}"`);
+      }
     }
   }
 

--- a/scripts/build-webrtc.bat
+++ b/scripts/build-webrtc.bat
@@ -6,7 +6,11 @@ set PATH=%DEPOT_TOOLS%;%PATH%
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ECHO ninja
-call autoninja webrtc libjingle_peerconnection libc++ libc++abi builtin_video_encoder_factory builtin_video_decoder_factory rtc_internal_video_codecs
+IF /I "%USE_CUSTOM_LIBCXX%"=="true" (
+  call autoninja webrtc create_peerconnection_factory libc++
+) ELSE (
+  call autoninja webrtc create_peerconnection_factory
+)
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 GOTO DONE

--- a/scripts/configure-webrtc.bat
+++ b/scripts/configure-webrtc.bat
@@ -9,6 +9,22 @@ ECHO SET DEPOT_TOOLS_WIN_TOOLCHAIN=0
 SET DEPOT_TOOLS_WIN_TOOLCHAIN=0
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
+IF NOT EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools" GOTO AFTER_VS_OVERRIDE
+ECHO SET GYP_MSVS_OVERRIDE_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools
+SET "GYP_MSVS_OVERRIDE_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
+ECHO SET GYP_MSVS_VERSION=2022
+SET "GYP_MSVS_VERSION=2022"
+ECHO SET vs2022_install=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools
+SET "vs2022_install=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
+IF NOT EXIST "C:\Program Files (x86)\Windows Kits\10" GOTO AFTER_GN_WIN_ARGS
+ECHO SET WINDOWSSDKDIR=C:\Program Files (x86)\Windows Kits\10
+SET "WINDOWSSDKDIR=C:\Program Files (x86)\Windows Kits\10"
+ECHO SET WDK_DIR=C:\Program Files (x86)\Windows Kits\10
+SET "WDK_DIR=C:\Program Files (x86)\Windows Kits\10"
+:AFTER_GN_WIN_ARGS
+:AFTER_VS_OVERRIDE
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
 ECHO cd SOURCE_DIR
 cd %SOURCE_DIR%
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR

--- a/scripts/download-webrtc.bat
+++ b/scripts/download-webrtc.bat
@@ -14,7 +14,7 @@ CALL gclient config --unmanaged --spec solutions=[{\"name\":\"src\",\"url\":\"ht
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ECHO gclient sync
-CALL gclient sync --nohooks --with_branch_heads -r %WEBRTC_REVISION% -R
+CALL gclient sync --jobs 1 --nohooks --with_branch_heads -r %WEBRTC_REVISION% -R
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ECHO lastchange
@@ -24,6 +24,8 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO update toolchain
 CALL python src\build\vs_toolchain.py update --force
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+CALL python "%~dp0patch-vs-toolchain.py" src\build\vs_toolchain.py
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ECHO download clang
 CALL python3 src\tools\clang\scripts\update.py
@@ -32,8 +34,8 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO rmdir webrtc
 rmdir webrtc
 
-ECHO mklink /D webrtc src
-mklink /D webrtc src
+ECHO mklink /J webrtc src
+mklink /J webrtc src
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 GOTO DONE

--- a/scripts/download-webrtc.sh
+++ b/scripts/download-webrtc.sh
@@ -8,7 +8,7 @@ export PATH=$DEPOT_TOOLS:$PATH
 
 gclient config --unmanaged --spec 'solutions=[{"name":"src","url":"https://webrtc.googlesource.com/src.git"}]'
 
-gclient sync --shallow --no-history --nohooks --with_branch_heads -r ${WEBRTC_REVISION} -R
+gclient sync --jobs 1 --shallow --no-history --nohooks --with_branch_heads -r ${WEBRTC_REVISION} -R
 
 vpython3 src/tools/clang/scripts/update.py
 

--- a/scripts/patch-vs-toolchain.py
+++ b/scripts/patch-vs-toolchain.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: patch-vs-toolchain.py <path-to-vs_toolchain.py>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    text = path.read_text(encoding="utf-8")
+    old = """      else:
+        raise Exception('%s not found in "%s"\\r\\nYou must install '
+                        'Windows 10 SDK version %s including the '
+                        '"Debugging Tools for Windows" feature.' %
+                        (debug_file, full_path, SDK_VERSION))
+"""
+    new = """      else:
+        print('%s not found in "%s"; skipping debugger runtime copy.' %
+              (debug_file, full_path))
+        return
+"""
+    if old not in text:
+        print(f"expected block not found in {path}", file=sys.stderr)
+        return 1
+
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+    print(f"patched {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -6,8 +6,11 @@
  * tree.
  */
 #include <cassert>
+#include <cstdlib>
+#include <cstring>
 #include <node-addon-api/napi.h>
 #include <uv.h>
+#include <webrtc/rtc_base/logging.h>
 
 #include "src/interfaces/media_stream.hh"
 #include "src/interfaces/media_stream_track.hh"
@@ -35,7 +38,33 @@
 
 static void dispose(void *) { node_webrtc::PeerConnectionFactory::Dispose(); }
 
+static webrtc::LoggingSeverity parseLogSeverity(const char* value) {
+  if (value == nullptr || *value == '\0') {
+    return webrtc::LoggingSeverity::LS_INFO;
+  }
+  if (std::strcmp(value, "verbose") == 0) {
+    return webrtc::LoggingSeverity::LS_VERBOSE;
+  }
+  if (std::strcmp(value, "warning") == 0) {
+    return webrtc::LoggingSeverity::LS_WARNING;
+  }
+  if (std::strcmp(value, "error") == 0) {
+    return webrtc::LoggingSeverity::LS_ERROR;
+  }
+  if (std::strcmp(value, "none") == 0) {
+    return webrtc::LoggingSeverity::LS_NONE;
+  }
+  return webrtc::LoggingSeverity::LS_INFO;
+}
+
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  if (const char* nativeLog = std::getenv("WRTC_NATIVE_LOG")) {
+    const auto severity = parseLogSeverity(nativeLog);
+    webrtc::LogMessage::SetLogToStderr(true);
+    webrtc::LogMessage::LogToDebug(severity);
+    RTC_LOG(LS_INFO) << "[wrtc] native logging enabled";
+  }
+
   node_webrtc::ErrorFactory::Init(env, exports);
   node_webrtc::GetDisplayMedia::Init(env, exports);
   node_webrtc::GetUserMedia::Init(env, exports);

--- a/src/dictionaries/node_webrtc/rtc_session_description_init.cc
+++ b/src/dictionaries/node_webrtc/rtc_session_description_init.cc
@@ -14,6 +14,20 @@ namespace node_webrtc {
 
 #define RTC_SESSION_DESCRIPTION_INIT_FN CreateValidRTCSessionDescriptionInit
 
+static webrtc::SdpType ToWebrtcSdpType(const RTCSdpType type) {
+  switch (type) {
+  case RTCSdpType::kOffer:
+    return webrtc::SdpType::kOffer;
+  case RTCSdpType::kPrAnswer:
+    return webrtc::SdpType::kPrAnswer;
+  case RTCSdpType::kAnswer:
+    return webrtc::SdpType::kAnswer;
+  case RTCSdpType::kRollback:
+    return webrtc::SdpType::kRollback;
+  }
+  return webrtc::SdpType::kOffer;
+}
+
 static Validation<RTC_SESSION_DESCRIPTION_INIT>
 RTC_SESSION_DESCRIPTION_INIT_FN(const RTCSdpType type, const std::string &sdp) {
   return Pure(CreateRTCSessionDescriptionInit(type, sdp));
@@ -30,27 +44,15 @@ TO_NAPI_IMPL(RTCSessionDescriptionInit, pair) {
 
 CONVERTER_IMPL(RTCSessionDescriptionInit, webrtc::SessionDescriptionInterface *,
                init) {
-  std::string type_;
-  switch (init.type) {
-  case RTCSdpType::kOffer:
-    type_ = "offer";
-    break;
-  case RTCSdpType::kPrAnswer:
-    type_ = "pranswer";
-    break;
-  case RTCSdpType::kAnswer:
-    type_ = "answer";
-    break;
-  case RTCSdpType::kRollback:
-    type_ = "rollback";
-  }
   webrtc::SdpParseError error;
-  auto description = webrtc::CreateSessionDescription(type_, init.sdp, &error);
+  auto description =
+      webrtc::CreateSessionDescription(ToWebrtcSdpType(init.type), init.sdp,
+                                       &error);
   if (!description) {
     return Validation<webrtc::SessionDescriptionInterface *>::Invalid(
         error.description);
   }
-  return Pure(description);
+  return Pure(description.release());
 }
 
 CONVERTER_IMPL(webrtc::SessionDescriptionInterface *, RTCSessionDescriptionInit,

--- a/src/dictionaries/webrtc/data_channel_init.cc
+++ b/src/dictionaries/webrtc/data_channel_init.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <optional>
 #include <string>
 
 #include <webrtc/api/data_channel_interface.h>
@@ -38,12 +39,12 @@ static Validation<webrtc::DataChannelInit> DATA_CHANNEL_INIT_FN(
   init.ordered = ordered;
   init.maxRetransmitTime =
       maxPacketLifeTime
-          .Map([](auto i) { return absl::make_optional(static_cast<int>(i)); })
-          .FromMaybe(absl::optional<int>());
+          .Map([](auto i) { return std::make_optional(static_cast<int>(i)); })
+          .FromMaybe(std::optional<int>());
   init.maxRetransmits =
       maxRetransmits
-          .Map([](auto i) { return absl::make_optional(static_cast<int>(i)); })
-          .FromMaybe(absl::optional<int>());
+          .Map([](auto i) { return std::make_optional(static_cast<int>(i)); })
+          .FromMaybe(std::optional<int>());
   init.protocol = protocol;
   init.negotiated = negotiated;
   init.id = id.Map([](auto i) { return static_cast<int>(i); }).FromMaybe(-1);

--- a/src/dictionaries/webrtc/ice_candidate_interface.cc
+++ b/src/dictionaries/webrtc/ice_candidate_interface.cc
@@ -67,18 +67,15 @@ TO_NAPI_IMPL(webrtc::IceCandidateInterface *, pair) {
   auto component = candidate.component() == 1 ? RTCIceComponent::kRtp
                                               : RTCIceComponent::kRtcp;
 
-  const auto &candidate_type = candidate.type();
+  const auto candidate_type = candidate.type();
   auto type = RTCIceCandidateType::kHost;
-  if (candidate_type == static_cast<const char *>(cricket::LOCAL_PORT_TYPE)) {
+  if (candidate_type == webrtc::IceCandidateType::kHost) {
     type = RTCIceCandidateType::kHost;
-  } else if (candidate_type ==
-             static_cast<const char *>(cricket::STUN_PORT_TYPE)) {
+  } else if (candidate_type == webrtc::IceCandidateType::kSrflx) {
     type = RTCIceCandidateType::kSrflx;
-  } else if (candidate_type ==
-             static_cast<const char *>(cricket::RELAY_PORT_TYPE)) {
+  } else if (candidate_type == webrtc::IceCandidateType::kRelay) {
     type = RTCIceCandidateType::kRelay;
-  } else if (candidate_type ==
-             static_cast<const char *>(cricket::PRFLX_PORT_TYPE)) {
+  } else if (candidate_type == webrtc::IceCandidateType::kPrflx) {
     type = RTCIceCandidateType::kPrflx;
   }
 

--- a/src/dictionaries/webrtc/ice_candidate_interface.hh
+++ b/src/dictionaries/webrtc/ice_candidate_interface.hh
@@ -2,11 +2,9 @@
 
 #include <memory>
 
-#include "src/converters/napi.hh"
+#include <webrtc/api/jsep.h>
 
-namespace webrtc {
-class IceCandidateInterface;
-}
+#include "src/converters/napi.hh"
 
 #define ICE_CANDIDATE_INTERFACE webrtc::IceCandidateInterface *
 

--- a/src/dictionaries/webrtc/rtc_stats.cc
+++ b/src/dictionaries/webrtc/rtc_stats.cc
@@ -23,9 +23,10 @@ TO_NAPI_IMPL(const webrtc::RTCStats *, pair) {
       static_cast<double>(value->timestamp().us()) / 1000.0)
   NODE_WEBRTC_CONVERT_AND_SET_OR_RETURN(env, stats, "type",
                                         std::string(value->type()))
-  for (const webrtc::RTCStatsMemberInterface *member : value->Members()) {
-    if (member->is_defined()) {
-      NODE_WEBRTC_CONVERT_AND_SET_OR_RETURN(env, stats, member->name(), member)
+  for (const auto &attribute : value->Attributes()) {
+    if (attribute.has_value()) {
+      NODE_WEBRTC_CONVERT_AND_SET_OR_RETURN(env, stats, attribute.name(),
+                                            &attribute)
     }
   }
   return Pure(scope.Escape(stats));

--- a/src/dictionaries/webrtc/rtc_stats_member_interface.cc
+++ b/src/dictionaries/webrtc/rtc_stats_member_interface.cc
@@ -1,86 +1,86 @@
 #include "src/dictionaries/webrtc/rtc_stats_member_interface.hh"
 
 #include <cstdint>
-#include <iosfwd>
+#include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <node-addon-api/napi.h>
-#include <webrtc/api/stats/rtc_stats.h>
+#include <webrtc/api/stats/attribute.h>
 
 #include "src/converters.hh"
 
 namespace node_webrtc {
 
-TO_NAPI_IMPL(const webrtc::RTCStatsMemberInterface *, pair) {
+TO_NAPI_IMPL(const webrtc::Attribute *, pair) {
   auto env = pair.first;
   auto value = pair.second;
-  switch (value->type()) {
-  case webrtc::RTCStatsMemberInterface::Type::kBool: // bool
-    return From<Napi::Value>(
-        std::make_pair(env, *value->cast_to<webrtc::RTCStatsMember<bool>>()));
-  case webrtc::RTCStatsMemberInterface::Type::kInt32: // int32_t
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<int32_t>>()));
-  case webrtc::RTCStatsMemberInterface::Type::kUint32: // uint32_t
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<uint32_t>>()));
-  case webrtc::RTCStatsMemberInterface::Type::kInt64: // int64_t
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<int64_t>>()));
-  case webrtc::RTCStatsMemberInterface::Type::kUint64: // uint64_t
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<uint64_t>>()));
-  case webrtc::RTCStatsMemberInterface::Type::kDouble: // double
-    return From<Napi::Value>(
-        std::make_pair(env, *value->cast_to<webrtc::RTCStatsMember<double>>()));
-  case webrtc::RTCStatsMemberInterface::Type::kString: // std::string
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<std::string>>()));
-  case webrtc::RTCStatsMemberInterface::Type::
-      kSequenceBool: // std::vector<bool>
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<std::vector<bool>>>()));
-  case webrtc::RTCStatsMemberInterface::Type::
-      kSequenceInt32: // std::vector<int32_t>
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<std::vector<int32_t>>>()));
-  case webrtc::RTCStatsMemberInterface::Type::
-      kSequenceUint32: // std::vector<uint32_t>
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<std::vector<uint32_t>>>()));
-  case webrtc::RTCStatsMemberInterface::Type::
-      kSequenceInt64: // std::vector<int64_t>
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<std::vector<int64_t>>>()));
-  case webrtc::RTCStatsMemberInterface::Type::
-      kSequenceUint64: // std::vector<uint64_t>
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<std::vector<uint64_t>>>()));
-  case webrtc::RTCStatsMemberInterface::Type::
-      kSequenceDouble: // std::vector<double>
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<webrtc::RTCStatsMember<std::vector<double>>>()));
-  case webrtc::RTCStatsMemberInterface::Type::
-      kSequenceString: // std::vector<std::string>
-    return From<Napi::Value>(std::make_pair(
-        env,
-        *value->cast_to<webrtc::RTCStatsMember<std::vector<std::string>>>()));
 
-  case webrtc::RTCStatsMemberInterface::Type::kMapStringUint64:
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<
-                 webrtc::RTCStatsMember<std::map<std::string, uint64_t>>>()));
-  case webrtc::RTCStatsMemberInterface::Type::kMapStringDouble:
-    return From<Napi::Value>(std::make_pair(
-        env, *value->cast_to<
-                 webrtc::RTCStatsMember<std::map<std::string, double>>>()));
-  default:
-    return Validation<Napi::Value>::Invalid(
-        "RTCStatsMemberInterface type not supported, file a bug against "
-        "node-webrtc");
+  if (!value || !value->has_value()) {
+    return Validation<Napi::Value>::Invalid("RTC stats attribute is undefined");
   }
+
+  if (value->holds_alternative<bool>()) {
+    return From<Napi::Value>(std::make_pair(env, value->get<bool>()));
+  }
+  if (value->holds_alternative<int32_t>()) {
+    return From<Napi::Value>(std::make_pair(env, value->get<int32_t>()));
+  }
+  if (value->holds_alternative<uint32_t>()) {
+    return From<Napi::Value>(std::make_pair(env, value->get<uint32_t>()));
+  }
+  if (value->holds_alternative<int64_t>()) {
+    return From<Napi::Value>(std::make_pair(env, value->get<int64_t>()));
+  }
+  if (value->holds_alternative<uint64_t>()) {
+    return From<Napi::Value>(std::make_pair(env, value->get<uint64_t>()));
+  }
+  if (value->holds_alternative<double>()) {
+    return From<Napi::Value>(std::make_pair(env, value->get<double>()));
+  }
+  if (value->holds_alternative<std::string>()) {
+    return From<Napi::Value>(std::make_pair(env, value->get<std::string>()));
+  }
+  if (value->holds_alternative<std::vector<bool>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::vector<bool>>()));
+  }
+  if (value->holds_alternative<std::vector<int32_t>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::vector<int32_t>>()));
+  }
+  if (value->holds_alternative<std::vector<uint32_t>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::vector<uint32_t>>()));
+  }
+  if (value->holds_alternative<std::vector<int64_t>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::vector<int64_t>>()));
+  }
+  if (value->holds_alternative<std::vector<uint64_t>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::vector<uint64_t>>()));
+  }
+  if (value->holds_alternative<std::vector<double>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::vector<double>>()));
+  }
+  if (value->holds_alternative<std::vector<std::string>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::vector<std::string>>()));
+  }
+  if (value->holds_alternative<std::map<std::string, uint64_t>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::map<std::string, uint64_t>>()));
+  }
+  if (value->holds_alternative<std::map<std::string, double>>()) {
+    return From<Napi::Value>(
+        std::make_pair(env, value->get<std::map<std::string, double>>()));
+  }
+
+  return Validation<Napi::Value>::Invalid(
+      "RTC stats attribute type not supported, file a bug against "
+      "node-webrtc");
 }
 
 } // namespace node_webrtc

--- a/src/dictionaries/webrtc/rtc_stats_member_interface.hh
+++ b/src/dictionaries/webrtc/rtc_stats_member_interface.hh
@@ -3,11 +3,11 @@
 #include "src/converters/napi.hh"
 
 namespace webrtc {
-class RTCStatsMemberInterface;
+class Attribute;
 }
 
 namespace node_webrtc {
 
-DECLARE_TO_NAPI(const webrtc::RTCStatsMemberInterface *)
+DECLARE_TO_NAPI(const webrtc::Attribute *)
 
 } // namespace node_webrtc

--- a/src/dictionaries/webrtc/rtc_stats_report.cc
+++ b/src/dictionaries/webrtc/rtc_stats_report.cc
@@ -61,7 +61,7 @@ static Maybe<Errors> DoSet(Napi::Object map, std::string const &key, T value) {
   return SetMap(map, maybeKey.UnsafeFromValid(), maybeValue.UnsafeFromValid());
 }
 
-TO_NAPI_IMPL(rtc::scoped_refptr<webrtc::RTCStatsReport>, pair) {
+TO_NAPI_IMPL(webrtc::scoped_refptr<webrtc::RTCStatsReport>, pair) {
   return CreateMap(pair.first)
       .FlatMap<Napi::Value>([value = pair.second](auto map) {
         auto env = map.Env();

--- a/src/dictionaries/webrtc/rtc_stats_report.hh
+++ b/src/dictionaries/webrtc/rtc_stats_report.hh
@@ -2,15 +2,13 @@
 
 #include "src/converters/napi.hh"
 
-namespace rtc {
-template <typename T> class scoped_refptr;
-}
 namespace webrtc {
 class RTCStatsReport;
+template <typename T> class scoped_refptr;
 }
 
 namespace node_webrtc {
 
-DECLARE_TO_NAPI(rtc::scoped_refptr<webrtc::RTCStatsReport>)
+DECLARE_TO_NAPI(webrtc::scoped_refptr<webrtc::RTCStatsReport>)
 
 } // namespace node_webrtc

--- a/src/dictionaries/webrtc/rtp_codec_capability.cc
+++ b/src/dictionaries/webrtc/rtp_codec_capability.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <node-addon-api/napi.h>
+#include <webrtc/api/media_types.h>
 #include <webrtc/api/rtp_parameters.h>
 
 #include "src/converters.hh"
@@ -55,8 +56,8 @@ CreateRtpCodecCapability(std::string const &mimeType, uint64_t clockRate,
   auto indexOfSlash = mimeType.find('/');
   auto kindString = mimeType.substr(0, indexOfSlash);
   auto nameString = mimeType.substr(indexOfSlash + 1);
-  result.kind = kindString == "audio" ? cricket::MEDIA_TYPE_AUDIO
-                                      : cricket::MEDIA_TYPE_VIDEO;
+  result.kind = kindString == "audio" ? webrtc::MediaType::AUDIO
+                                      : webrtc::MediaType::VIDEO;
   result.name = nameString;
   result.clock_rate = clockRate;
   if (channels.IsJust()) {

--- a/src/dictionaries/webrtc/rtp_codec_parameters.cc
+++ b/src/dictionaries/webrtc/rtp_codec_parameters.cc
@@ -8,6 +8,7 @@
 
 #include <absl/types/optional.h>
 #include <node-addon-api/napi.h>
+#include <webrtc/api/media_types.h>
 #include <webrtc/api/rtp_parameters.h>
 
 #include "src/converters.hh"
@@ -60,8 +61,8 @@ static webrtc::RtpCodecParameters NapiToRtpCodecParameters(
   auto indexOfSlash = mimeType.find('/');
   auto kindString = mimeType.substr(0, indexOfSlash);
   auto nameString = mimeType.substr(indexOfSlash + 1);
-  result.kind = kindString == "audio" ? cricket::MEDIA_TYPE_AUDIO
-                                      : cricket::MEDIA_TYPE_VIDEO;
+  result.kind = kindString == "audio" ? webrtc::MediaType::AUDIO
+                                      : webrtc::MediaType::VIDEO;
   result.name = nameString;
   result.payload_type = payloadType;
   result.clock_rate = clockRate;

--- a/src/dictionaries/webrtc/rtp_source.cc
+++ b/src/dictionaries/webrtc/rtp_source.cc
@@ -16,7 +16,7 @@ TO_NAPI_IMPL(webrtc::RtpSource, pair) {
   auto source = pair.second;
   NODE_WEBRTC_CREATE_OBJECT_OR_RETURN(env, object)
   NODE_WEBRTC_CONVERT_AND_SET_OR_RETURN(env, object, "timestamp",
-                                        source.timestamp_ms())
+                                        source.timestamp().ms<double>())
   NODE_WEBRTC_CONVERT_AND_SET_OR_RETURN(env, object, "source",
                                         source.source_id())
   return Pure(scope.Escape(object));

--- a/src/dictionaries/webrtc/video_frame_buffer.cc
+++ b/src/dictionaries/webrtc/video_frame_buffer.cc
@@ -8,7 +8,7 @@
 
 namespace node_webrtc {
 
-static rtc::scoped_refptr<webrtc::I420Buffer>
+static webrtc::scoped_refptr<webrtc::I420Buffer>
 CreateI420Buffer(I420ImageData i420Frame) {
   auto buffer =
       webrtc::I420Buffer::Create(i420Frame.width(), i420Frame.height());
@@ -21,11 +21,12 @@ CreateI420Buffer(I420ImageData i420Frame) {
   return buffer;
 }
 
-CONVERTER_IMPL(I420ImageData, rtc::scoped_refptr<webrtc::I420Buffer>, value) {
+CONVERTER_IMPL(I420ImageData, webrtc::scoped_refptr<webrtc::I420Buffer>,
+               value) {
   return Pure(CreateI420Buffer(value));
 }
 
-TO_NAPI_IMPL(rtc::scoped_refptr<webrtc::VideoFrameBuffer>, pair) {
+TO_NAPI_IMPL(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>, pair) {
   auto value = pair.second;
   return value->type() == webrtc::VideoFrameBuffer::Type::kI420
              ? From<Napi::Value>(std::make_pair(pair.first, value->GetI420()))
@@ -34,7 +35,8 @@ TO_NAPI_IMPL(rtc::scoped_refptr<webrtc::VideoFrameBuffer>, pair) {
                    "please!)");
 }
 
-CONVERT_VIA(Napi::Value, I420ImageData, rtc::scoped_refptr<webrtc::I420Buffer>)
+CONVERT_VIA(Napi::Value, I420ImageData,
+            webrtc::scoped_refptr<webrtc::I420Buffer>)
 
 TO_NAPI_IMPL(const webrtc::I420BufferInterface *, pair) {
   auto env = pair.first;

--- a/src/dictionaries/webrtc/video_frame_buffer.hh
+++ b/src/dictionaries/webrtc/video_frame_buffer.hh
@@ -3,10 +3,8 @@
 #include "src/converters.hh"
 #include "src/converters/napi.hh"
 
-namespace rtc {
-template <typename T> class scoped_refptr;
-}
 namespace webrtc {
+template <typename T> class scoped_refptr;
 class I420Buffer;
 }
 namespace webrtc {
@@ -20,10 +18,10 @@ namespace node_webrtc {
 
 class I420ImageData;
 
-DECLARE_CONVERTER(I420ImageData, rtc::scoped_refptr<webrtc::I420Buffer>)
+DECLARE_CONVERTER(I420ImageData, webrtc::scoped_refptr<webrtc::I420Buffer>)
 
-DECLARE_FROM_NAPI(rtc::scoped_refptr<webrtc::I420Buffer>)
+DECLARE_FROM_NAPI(webrtc::scoped_refptr<webrtc::I420Buffer>)
 DECLARE_TO_NAPI(const webrtc::I420BufferInterface *)
-DECLARE_TO_NAPI(rtc::scoped_refptr<webrtc::VideoFrameBuffer>)
+DECLARE_TO_NAPI(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>)
 
 } // namespace node_webrtc

--- a/src/enums/webrtc/ice_role.hh
+++ b/src/enums/webrtc/ice_role.hh
@@ -4,7 +4,7 @@
 
 // IWYU pragma: no_include "src/enums/macros/impls.hh"
 
-#define ICE_ROLE cricket::IceRole
+#define ICE_ROLE webrtc::IceRole
 #define ICE_ROLE_NAME "RTCIceRole"
 #define ICE_ROLE_LIST                                                          \
   ENUM_SUPPORTED(ICE_ROLE::ICEROLE_CONTROLLING, "controlling")                 \

--- a/src/enums/webrtc/media_type.cc
+++ b/src/enums/webrtc/media_type.cc
@@ -1,5 +1,5 @@
 #include "src/enums/webrtc/media_type.hh"
 
-#define ENUM(X) CRICKET_MEDIA_TYPE##X
+#define ENUM(X) WEBRTC_MEDIA_TYPE##X
 #include "src/enums/macros/impls.hh"
 #undef ENUM

--- a/src/enums/webrtc/media_type.hh
+++ b/src/enums/webrtc/media_type.hh
@@ -5,15 +5,15 @@
 // IWYU pragma: no_include "src/enums/macros/impls.hh"
 
 // FIXME(mroberts): I'm not sure that "data" should be valid.
-#define CRICKET_MEDIA_TYPE cricket::MediaType
-#define CRICKET_MEDIA_TYPE_NAME "kind"
-#define CRICKET_MEDIA_TYPE_LIST                                                \
-  ENUM_SUPPORTED(CRICKET_MEDIA_TYPE::MEDIA_TYPE_AUDIO, "audio")                \
-  ENUM_SUPPORTED(CRICKET_MEDIA_TYPE::MEDIA_TYPE_VIDEO, "video")                \
-  ENUM_SUPPORTED(CRICKET_MEDIA_TYPE::MEDIA_TYPE_DATA, "data")                  \
-  ENUM_UNSUPPORTED(CRICKET_MEDIA_TYPE::MEDIA_TYPE_UNSUPPORTED, "unsupported",  \
+#define WEBRTC_MEDIA_TYPE webrtc::MediaType
+#define WEBRTC_MEDIA_TYPE_NAME "kind"
+#define WEBRTC_MEDIA_TYPE_LIST                                                 \
+  ENUM_SUPPORTED(WEBRTC_MEDIA_TYPE::AUDIO, "audio")                           \
+  ENUM_SUPPORTED(WEBRTC_MEDIA_TYPE::VIDEO, "video")                           \
+  ENUM_SUPPORTED(WEBRTC_MEDIA_TYPE::DATA, "data")                             \
+  ENUM_UNSUPPORTED(WEBRTC_MEDIA_TYPE::UNSUPPORTED, "unsupported",             \
                    "Unsupported media type is not supported")
 
-#define ENUM(X) CRICKET_MEDIA_TYPE##X
+#define ENUM(X) WEBRTC_MEDIA_TYPE##X
 #include "src/enums/macros/decls.hh"
 #undef ENUM

--- a/src/interfaces/media_stream.cc
+++ b/src/interfaces/media_stream.cc
@@ -12,6 +12,7 @@
 #include <webrtc/api/media_stream_interface.h>
 #include <webrtc/api/peer_connection_interface.h>
 #include <webrtc/api/scoped_refptr.h>
+#include <webrtc/rtc_base/crypto_random.h>
 
 #include "src/converters.hh"
 #include "src/converters/arguments.hh"

--- a/src/interfaces/media_stream_track.cc
+++ b/src/interfaces/media_stream_track.cc
@@ -7,12 +7,12 @@
  */
 #include "src/interfaces/media_stream_track.hh"
 
+#include <absl/strings/string_view.h>
 #include <node-addon-api/napi.h>
-#include <src/api/scoped_refptr.h>
-#include <src/third_party/abseil-cpp/absl/strings/string_view.h>
 #include <webrtc/api/media_stream_interface.h>
 #include <webrtc/api/peer_connection_interface.h>
-#include <webrtc/rtc_base/helpers.h>
+#include <webrtc/api/scoped_refptr.h>
+#include <webrtc/rtc_base/crypto_random.h>
 
 #include "src/converters.hh"
 #include "src/converters/interfaces.hh"

--- a/src/interfaces/rtc_audio_source.cc
+++ b/src/interfaces/rtc_audio_source.cc
@@ -9,6 +9,7 @@
 
 #include <webrtc/api/peer_connection_interface.h>
 #include <webrtc/rtc_base/ref_counted_object.h>
+#include <webrtc/rtc_base/crypto_random.h>
 
 #include "src/converters.hh"
 #include "src/converters/arguments.hh"

--- a/src/interfaces/rtc_data_channel.cc
+++ b/src/interfaces/rtc_data_channel.cc
@@ -21,6 +21,14 @@
 
 namespace node_webrtc {
 
+namespace {
+
+Napi::Value OptionalIntToNapi(Napi::Env env, const std::optional<int> &value) {
+  return value ? Napi::Number::New(env, *value) : env.Null();
+}
+
+} // namespace
+
 Napi::FunctionReference &RTCDataChannel::constructor() {
   static Napi::FunctionReference constructor;
   return constructor;
@@ -79,8 +87,8 @@ RTCDataChannel::RTCDataChannel(const Napi::CallbackInfo &info)
 
   // NOTE(mroberts): These doesn't actually matter yet.
   _cached_id = 0;
-  _cached_max_packet_life_time = 0;
-  _cached_max_retransmits = 0;
+  _cached_max_packet_life_time = std::nullopt;
+  _cached_max_retransmits = std::nullopt;
   _cached_negotiated = false;
   _cached_ordered = false;
   _cached_buffered_amount = 0;
@@ -95,8 +103,8 @@ void RTCDataChannel::CleanupInternals() {
   _jingleDataChannel->UnregisterObserver();
   _cached_id = _jingleDataChannel->id();
   _cached_label = _jingleDataChannel->label();
-  _cached_max_packet_life_time = _jingleDataChannel->maxRetransmitTime();
-  _cached_max_retransmits = _jingleDataChannel->maxRetransmits();
+  _cached_max_packet_life_time = _jingleDataChannel->maxPacketLifeTime();
+  _cached_max_retransmits = _jingleDataChannel->maxRetransmitsOpt();
   _cached_negotiated = _jingleDataChannel->negotiated();
   _cached_ordered = _jingleDataChannel->ordered();
   _cached_protocol = _jingleDataChannel->protocol();
@@ -261,20 +269,16 @@ Napi::Value RTCDataChannel::GetLabel(const Napi::CallbackInfo &info) {
 Napi::Value
 RTCDataChannel::GetMaxPacketLifeTime(const Napi::CallbackInfo &info) {
   auto max_packet_life_time = _jingleDataChannel
-                                  ? _jingleDataChannel->maxRetransmitTime()
+                                  ? _jingleDataChannel->maxPacketLifeTime()
                                   : _cached_max_packet_life_time;
-  CONVERT_OR_THROW_AND_RETURN_NAPI(info.Env(), max_packet_life_time, result,
-                                   Napi::Value)
-  return result;
+  return OptionalIntToNapi(info.Env(), max_packet_life_time);
 }
 
 Napi::Value RTCDataChannel::GetMaxRetransmits(const Napi::CallbackInfo &info) {
   auto max_retransmits = _jingleDataChannel
-                             ? _jingleDataChannel->maxRetransmits()
+                             ? _jingleDataChannel->maxRetransmitsOpt()
                              : _cached_max_retransmits;
-  CONVERT_OR_THROW_AND_RETURN_NAPI(info.Env(), max_retransmits, result,
-                                   Napi::Value)
-  return result;
+  return OptionalIntToNapi(info.Env(), max_retransmits);
 }
 
 Napi::Value RTCDataChannel::GetNegotiated(const Napi::CallbackInfo &info) {

--- a/src/interfaces/rtc_data_channel.hh
+++ b/src/interfaces/rtc_data_channel.hh
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <optional>
+
 #include <webrtc/api/data_channel_interface.h>
 #include <webrtc/api/scoped_refptr.h>
 
@@ -81,8 +83,8 @@ private:
   BinaryType _binaryType;
   int _cached_id;
   std::string _cached_label;
-  uint16_t _cached_max_packet_life_time;
-  uint16_t _cached_max_retransmits;
+  std::optional<int> _cached_max_packet_life_time;
+  std::optional<int> _cached_max_retransmits;
   bool _cached_negotiated;
   bool _cached_ordered;
   std::string _cached_protocol;

--- a/src/interfaces/rtc_ice_transport.cc
+++ b/src/interfaces/rtc_ice_transport.cc
@@ -41,10 +41,14 @@ RTCIceTransport::RTCIceTransport(const Napi::CallbackInfo &info)
   _factory->WorkerThread()->BlockingCall([this]() {
     auto internal = _transport->internal();
     if (internal) {
-      internal->SignalIceTransportStateChanged.connect(
-          this, &RTCIceTransport::OnStateChanged);
-      internal->SignalGatheringState.connect(
-          this, &RTCIceTransport::OnGatheringStateChanged);
+      internal->SubscribeIceTransportStateChanged(
+          this, [this](webrtc::IceTransportInternal *transport) {
+            OnStateChanged(transport);
+          });
+      internal->AddGatheringStateCallback(
+          this, [this](webrtc::IceTransportInternal *transport) {
+            OnGatheringStateChanged(transport);
+          });
     }
     TakeSnapshot();
     if (_state == webrtc::IceTransportState::kClosed) {
@@ -64,7 +68,7 @@ void RTCIceTransport::TakeSnapshot() {
     _gathering_state = internal->gathering_state();
   } else {
     _state = webrtc::IceTransportState::kClosed;
-    _gathering_state = cricket::IceGatheringState::kIceGatheringComplete;
+    _gathering_state = webrtc::IceGatheringState::kIceGatheringComplete;
   }
 }
 
@@ -73,15 +77,17 @@ RTCIceTransport::~RTCIceTransport() { wrap()->Release(this); }
 void RTCIceTransport::OnRTCDtlsTransportStopped() {
   std::lock_guard<std::mutex> lock(_mutex);
   _state = webrtc::IceTransportState::kClosed;
-  _gathering_state = cricket::IceGatheringState::kIceGatheringComplete;
+  _gathering_state = webrtc::IceGatheringState::kIceGatheringComplete;
   Stop();
 }
 
 void RTCIceTransport::Stop() {
-  // _factory->_workerThread->Invoke<void>(RTC_FROM_HERE, [this]() {
-  //   _transport->internal()->SignalIceTransportStateChanged.disconnect(this);
-  //   _transport->internal()->SignalGatheringState.disconnect(this);
-  // });
+  if (_transport) {
+    auto internal = _transport->internal();
+    if (internal) {
+      internal->RemoveGatheringStateCallback(this);
+    }
+  }
   AsyncObjectWrapWithLoop<RTCIceTransport>::Stop();
 }
 
@@ -110,7 +116,7 @@ RTCIceTransport *RTCIceTransport::Create(
   return unwrapped;
 }
 
-void RTCIceTransport::OnStateChanged(cricket::IceTransportInternal *) {
+void RTCIceTransport::OnStateChanged(webrtc::IceTransportInternal *) {
   TakeSnapshot();
 
   Dispatch(CreateCallback<RTCIceTransport>([this]() {
@@ -126,7 +132,8 @@ void RTCIceTransport::OnStateChanged(cricket::IceTransportInternal *) {
   }
 }
 
-void RTCIceTransport::OnGatheringStateChanged(cricket::IceTransportInternal *) {
+void RTCIceTransport::OnGatheringStateChanged(
+    webrtc::IceTransportInternal *) {
   TakeSnapshot();
 
   Dispatch(CreateCallback<RTCIceTransport>([this]() {
@@ -160,15 +167,15 @@ Napi::Value RTCIceTransport::GetGatheringState(const Napi::CallbackInfo &info) {
   std::lock_guard<std::mutex> lock(_mutex);
   webrtc::PeerConnectionInterface::IceGatheringState state = {};
   switch (_gathering_state) {
-  case cricket::IceGatheringState::kIceGatheringNew:
+  case webrtc::IceGatheringState::kIceGatheringNew:
     state =
         webrtc::PeerConnectionInterface::IceGatheringState::kIceGatheringNew;
     break;
-  case cricket::IceGatheringState::kIceGatheringGathering:
+  case webrtc::IceGatheringState::kIceGatheringGathering:
     state = webrtc::PeerConnectionInterface::IceGatheringState::
         kIceGatheringGathering;
     break;
-  case cricket::IceGatheringState::kIceGatheringComplete:
+  case webrtc::IceGatheringState::kIceGatheringComplete:
     state = webrtc::PeerConnectionInterface::IceGatheringState::
         kIceGatheringComplete;
     break;

--- a/src/interfaces/rtc_ice_transport.hh
+++ b/src/interfaces/rtc_ice_transport.hh
@@ -13,24 +13,17 @@
 #include <webrtc/api/ice_transport_interface.h>
 #include <webrtc/api/scoped_refptr.h>
 #include <webrtc/p2p/base/ice_transport_internal.h>
-#include <webrtc/rtc_base/third_party/sigslot/sigslot.h>
 
 #include "src/enums/node_webrtc/rtc_ice_component.hh"
 #include "src/node/async_object_wrap_with_loop.hh"
 #include "src/node/ref_ptr.hh"
 #include "src/node/wrap.hh"
 
-namespace cricket {
-class IceTransportInternal;
-}
-
 namespace node_webrtc {
 
 class PeerConnectionFactory;
 
-class RTCIceTransport
-    : public AsyncObjectWrapWithLoop<RTCIceTransport>,
-      public sigslot::has_slots<sigslot::multi_threaded_local> {
+class RTCIceTransport : public AsyncObjectWrapWithLoop<RTCIceTransport> {
 public:
   explicit RTCIceTransport(const Napi::CallbackInfo &);
   ~RTCIceTransport() override;
@@ -59,8 +52,8 @@ private:
   Create(PeerConnectionFactory *,
          rtc::scoped_refptr<webrtc::IceTransportInterface>);
 
-  void OnStateChanged(cricket::IceTransportInternal *);
-  void OnGatheringStateChanged(cricket::IceTransportInternal *);
+  void OnStateChanged(webrtc::IceTransportInternal *);
+  void OnGatheringStateChanged(webrtc::IceTransportInternal *);
 
   void TakeSnapshot();
 
@@ -77,10 +70,10 @@ private:
 
   RTCIceComponent _component = RTCIceComponent::kRtp;
   RefPtr<PeerConnectionFactory> _factory;
-  cricket::IceGatheringState _gathering_state =
-      cricket::IceGatheringState::kIceGatheringNew;
+  webrtc::IceGatheringState _gathering_state =
+      webrtc::IceGatheringState::kIceGatheringNew;
   std::mutex _mutex{};
-  cricket::IceRole _role = cricket::IceRole::ICEROLE_UNKNOWN;
+  webrtc::IceRole _role = webrtc::IceRole::ICEROLE_UNKNOWN;
   webrtc::IceTransportState _state = webrtc::IceTransportState::kNew;
   rtc::scoped_refptr<webrtc::IceTransportInterface> _transport;
 };

--- a/src/interfaces/rtc_peer_connection.cc
+++ b/src/interfaces/rtc_peer_connection.cc
@@ -8,7 +8,7 @@
 #include "src/interfaces/rtc_peer_connection.hh"
 
 #include <iostream>
-#include <src/api/jsep.h>
+#include <webrtc/api/jsep.h>
 #include <webrtc/api/media_types.h>
 #include <webrtc/api/peer_connection_interface.h>
 #include <webrtc/api/rtc_error.h>
@@ -88,8 +88,9 @@ RTCPeerConnection::RTCPeerConnection(const Napi::CallbackInfo &info)
   _shouldReleaseFactory = true;
 
   auto portAllocator =
-      std::unique_ptr<cricket::PortAllocator>(new cricket::BasicPortAllocator(
-          _factory->getNetworkManager(), _factory->getSocketFactory()));
+      std::unique_ptr<webrtc::PortAllocator>(new webrtc::BasicPortAllocator(
+          _factory->env(), _factory->getNetworkManager(),
+          _factory->getSocketFactory()));
   _port_range = configuration.portRange;
   portAllocator->SetPortRange(_port_range.min.FromMaybe(0),
                               _port_range.max.FromMaybe(65535));
@@ -354,9 +355,9 @@ Napi::Value RTCPeerConnection::AddTransceiver(const Napi::CallbackInfo &info) {
 
   CONVERT_ARGS_OR_THROW_AND_RETURN_NAPI(
       info, args,
-      std::tuple<Either<cricket::MediaType COMMA MediaStreamTrack *> COMMA
+      std::tuple<Either<webrtc::MediaType COMMA MediaStreamTrack *> COMMA
                      Maybe<webrtc::RtpTransceiverInit>>)
-  Either<cricket::MediaType, MediaStreamTrack *> kindOrTrack =
+  Either<webrtc::MediaType, MediaStreamTrack *> kindOrTrack =
       std::get<0>(args);
   Maybe<webrtc::RtpTransceiverInit> maybeInit = std::get<1>(args);
   auto result =

--- a/src/interfaces/rtc_peer_connection.hh
+++ b/src/interfaces/rtc_peer_connection.hh
@@ -28,7 +28,6 @@
 namespace webrtc {
 
 class DataChannelInterface;
-class IceCandidateInterface;
 class MediaStreamInterface;
 class RtpReceiverInterface;
 class RtpTransceiverInterface;

--- a/src/interfaces/rtc_peer_connection/peer_connection_factory.cc
+++ b/src/interfaces/rtc_peer_connection/peer_connection_factory.cc
@@ -9,12 +9,11 @@
 
 #include <memory>
 
+#include <webrtc/api/environment/environment_factory.h>
 #include <webrtc/api/audio_codecs/builtin_audio_decoder_factory.h>
 #include <webrtc/api/audio_codecs/builtin_audio_encoder_factory.h>
 #include <webrtc/api/create_peerconnection_factory.h>
 #include <webrtc/api/peer_connection_interface.h>
-#include <webrtc/api/video_codecs/builtin_video_decoder_factory.h>
-#include <webrtc/api/video_codecs/builtin_video_encoder_factory.h>
 #include <webrtc/api/video_codecs/video_decoder_factory.h>
 #include <webrtc/api/video_codecs/video_encoder_factory.h>
 #include <webrtc/modules/audio_device/include/audio_device.h>
@@ -25,6 +24,7 @@
 #include <webrtc/rtc_base/thread.h>
 
 #include "src/functional/maybe.hh"
+#include "src/webrtc/packet_socket_factory_with_tls_cert_verifier.hh"
 #include "src/webrtc/test_audio_device_module.hh"
 
 namespace node_webrtc {
@@ -39,7 +39,8 @@ std::mutex PeerConnectionFactory::_mutex{};                       // NOLINT
 int PeerConnectionFactory::_references = 0;                       // NOLINT
 
 PeerConnectionFactory::PeerConnectionFactory(const Napi::CallbackInfo &info)
-    : Napi::ObjectWrap<PeerConnectionFactory>(info) {
+    : Napi::ObjectWrap<PeerConnectionFactory>(info),
+      _env(webrtc::CreateEnvironment()) {
   auto env = info.Env();
 
   if (!info.IsConstructCall()) {
@@ -48,9 +49,6 @@ PeerConnectionFactory::PeerConnectionFactory(const Napi::CallbackInfo &info)
         .ThrowAsJavaScriptException();
     return;
   }
-
-  // TODO(mroberts): Read `audioLayer` from some PeerConnectionFactoryOptions?
-  auto audioLayer = MakeNothing<webrtc::AudioDeviceModule::AudioLayer>();
 
   _workerThread = rtc::Thread::CreateWithSocketServer();
   assert(_workerThread);
@@ -64,20 +62,10 @@ PeerConnectionFactory::PeerConnectionFactory(const Napi::CallbackInfo &info)
   assert(result);
   (void)result;
 
-  _audioDeviceModule = _workerThread->BlockingCall([audioLayer]() {
-    return audioLayer
-        .Map([](auto audioLayer) {
-          // TODO(mroberts): I'm just trying to get this to compile
-          // right now. We need to call something like
-          // CreateDefaultTaskQueueFactory(). This code is currently
-          // unused, though.
-          return webrtc::AudioDeviceModule::Create(audioLayer, nullptr);
-        })
-        .Or([]() {
-          return TestAudioDeviceModule::CreateTestAudioDeviceModule(
-              TestAudioDeviceModule::CreateZeroCapturer(48000, 1),
-              TestAudioDeviceModule::CreateDiscardRenderer(48000));
-        });
+  _audioDeviceModule = _workerThread->BlockingCall([]() {
+    return TestAudioDeviceModule::CreateTestAudioDeviceModule(
+        TestAudioDeviceModule::CreateZeroCapturer(48000, 1),
+        TestAudioDeviceModule::CreateDiscardRenderer(48000));
   });
 
   _signalingThread = rtc::Thread::Create();
@@ -95,9 +83,8 @@ PeerConnectionFactory::PeerConnectionFactory(const Napi::CallbackInfo &info)
   _factory = webrtc::CreatePeerConnectionFactory(
       _workerThread.get(), _workerThread.get(), _signalingThread.get(),
       _audioDeviceModule, webrtc::CreateBuiltinAudioEncoderFactory(),
-      webrtc::CreateBuiltinAudioDecoderFactory(),
-      webrtc::CreateBuiltinVideoEncoderFactory(),
-      webrtc::CreateBuiltinVideoDecoderFactory(), nullptr, nullptr);
+      webrtc::CreateBuiltinAudioDecoderFactory(), nullptr, nullptr, nullptr,
+      nullptr);
   assert(_factory);
 
   webrtc::PeerConnectionFactoryInterface::Options options;
@@ -105,11 +92,14 @@ PeerConnectionFactory::PeerConnectionFactory(const Napi::CallbackInfo &info)
   _factory->SetOptions(options);
 
   _networkManager = std::unique_ptr<rtc::NetworkManager>(
-      new rtc::BasicNetworkManager(_workerThread->socketserver()));
+      new rtc::BasicNetworkManager(_env, _workerThread->socketserver()));
   assert(_networkManager != nullptr);
 
   _socketFactory = std::unique_ptr<rtc::PacketSocketFactory>(
-      new rtc::BasicPacketSocketFactory(_workerThread->socketserver()));
+      new PacketSocketFactoryWithTlsCertVerifier(
+          std::unique_ptr<rtc::PacketSocketFactory>(
+              new rtc::BasicPacketSocketFactory(
+                  _workerThread->socketserver()))));
   assert(_socketFactory != nullptr);
 }
 

--- a/src/interfaces/rtc_peer_connection/peer_connection_factory.hh
+++ b/src/interfaces/rtc_peer_connection/peer_connection_factory.hh
@@ -11,6 +11,7 @@
 #include <mutex>
 
 #include <node-addon-api/napi.h>
+#include <webrtc/api/environment/environment.h>
 #include <webrtc/api/peer_connection_interface.h>
 #include <webrtc/api/scoped_refptr.h>
 #include <webrtc/modules/audio_device/include/audio_device.h>
@@ -47,6 +48,8 @@ public:
     return _factory;
   }
 
+  const webrtc::Environment &env() const { return _env; }
+
   std::unique_ptr<rtc::Thread> &SignalingThread() { return _signalingThread; }
 
   std::unique_ptr<rtc::Thread> &WorkerThread() { return _workerThread; }
@@ -62,6 +65,7 @@ public:
   static void Dispose();
 
 private:
+  webrtc::Environment _env;
   std::unique_ptr<rtc::Thread> _signalingThread;
   std::unique_ptr<rtc::Thread> _workerThread;
 

--- a/src/interfaces/rtc_rtp_receiver.cc
+++ b/src/interfaces/rtc_rtp_receiver.cc
@@ -72,8 +72,8 @@ Napi::Value RTCRtpReceiver::GetCapabilities(const Napi::CallbackInfo &info) {
   CONVERT_ARGS_OR_THROW_AND_RETURN_NAPI(info, kindString, std::string)
   if (kindString == "audio" || kindString == "video") {
     auto factory = PeerConnectionFactory::GetOrCreateDefault();
-    auto kind = kindString == "audio" ? cricket::MEDIA_TYPE_AUDIO
-                                      : cricket::MEDIA_TYPE_VIDEO;
+    auto kind = kindString == "audio" ? webrtc::MediaType::AUDIO
+                                      : webrtc::MediaType::VIDEO;
     auto capabilities = factory->factory()->GetRtpReceiverCapabilities(kind);
     PeerConnectionFactory::Release();
     CONVERT_OR_THROW_AND_RETURN_NAPI(info.Env(), capabilities, result,

--- a/src/interfaces/rtc_rtp_sender.cc
+++ b/src/interfaces/rtc_rtp_sender.cc
@@ -77,8 +77,8 @@ Napi::Value RTCRtpSender::GetCapabilities(const Napi::CallbackInfo &info) {
   CONVERT_ARGS_OR_THROW_AND_RETURN_NAPI(info, kindString, std::string)
   if (kindString == "audio" || kindString == "video") {
     auto factory = PeerConnectionFactory::GetOrCreateDefault();
-    auto kind = kindString == "audio" ? cricket::MEDIA_TYPE_AUDIO
-                                      : cricket::MEDIA_TYPE_VIDEO;
+    auto kind = kindString == "audio" ? webrtc::MediaType::AUDIO
+                                      : webrtc::MediaType::VIDEO;
     auto capabilities = factory->factory()->GetRtpSenderCapabilities(kind);
     PeerConnectionFactory::Release();
     CONVERT_OR_THROW_AND_RETURN_NAPI(info.Env(), capabilities, result,
@@ -128,8 +128,8 @@ Napi::Value RTCRtpSender::ReplaceTrack(const Napi::CallbackInfo &info) {
   if (track) {
     auto expectedMediaType =
         track->kind() == webrtc::MediaStreamTrackInterface::kAudioKind
-            ? cricket::MediaType::MEDIA_TYPE_AUDIO
-            : cricket::MediaType::MEDIA_TYPE_VIDEO;
+            ? webrtc::MediaType::AUDIO
+            : webrtc::MediaType::VIDEO;
     if (_sender->media_type() != expectedMediaType) {
       Reject(deferred, Napi::TypeError::New(info.Env(), "Kind does not match")
                            .Value()

--- a/src/interfaces/rtc_rtp_transceiver.cc
+++ b/src/interfaces/rtc_rtp_transceiver.cc
@@ -7,6 +7,7 @@
  */
 #include "src/interfaces/rtc_rtp_transceiver.hh"
 
+#include <webrtc/api/array_view.h>
 #include <webrtc/api/rtp_transceiver_interface.h>
 #include <webrtc/api/scoped_refptr.h>
 
@@ -113,11 +114,11 @@ Napi::Value RTCRtpTransceiver::Stop(const Napi::CallbackInfo &info) {
   return info.Env().Undefined();
 }
 
-Napi::Value
+  Napi::Value
 RTCRtpTransceiver::SetCodecPreferences(const Napi::CallbackInfo &info) {
   CONVERT_ARGS_OR_THROW_AND_RETURN_NAPI(info, codecs,
                                         std::vector<webrtc::RtpCodecCapability>)
-  auto capabilities = rtc::ArrayView<webrtc::RtpCodecCapability>(codecs);
+  auto capabilities = webrtc::ArrayView<webrtc::RtpCodecCapability>(codecs);
   auto error = _transceiver->SetCodecPreferences(capabilities);
   if (!error.ok()) {
     CONVERT_OR_THROW_AND_RETURN_NAPI(info.Env(), &error, result, Napi::Value)

--- a/src/interfaces/rtc_video_source.cc
+++ b/src/interfaces/rtc_video_source.cc
@@ -10,6 +10,7 @@
 #include <webrtc/api/peer_connection_interface.h>
 #include <webrtc/api/video/i420_buffer.h>
 #include <webrtc/api/video/video_frame.h>
+#include <webrtc/rtc_base/crypto_random.h>
 #include <webrtc/rtc_base/ref_counted_object.h>
 
 #include "src/converters/absl.hh"

--- a/src/methods/get_user_media.cc
+++ b/src/methods/get_user_media.cc
@@ -10,6 +10,7 @@
 #include <src/api/media_stream_interface.h>
 #include <webrtc/api/audio_options.h>
 #include <webrtc/api/peer_connection_interface.h>
+#include <webrtc/rtc_base/crypto_random.h>
 
 #include "src/converters.hh"
 #include "src/converters/arguments.hh"
@@ -133,7 +134,7 @@ node_webrtc::GetUserMedia::GetUserMediaImpl(const Napi::CallbackInfo &info) {
           .FromMaybe(false);
 
   if (audio) {
-    cricket::AudioOptions options;
+    webrtc::AudioOptions options;
     auto source = factory->factory()->CreateAudioSource(options);
     auto track = factory->factory()->CreateAudioTrack(rtc::CreateRandomUuid(),
                                                       source.get());

--- a/src/webrtc/packet_socket_factory_with_tls_cert_verifier.cc
+++ b/src/webrtc/packet_socket_factory_with_tls_cert_verifier.cc
@@ -1,0 +1,94 @@
+/* Copyright (c) 2026 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#include "src/webrtc/packet_socket_factory_with_tls_cert_verifier.hh"
+
+#include <utility>
+
+#include <webrtc/rtc_base/logging.h>
+
+#include "src/webrtc/windows_platform_certificate_verifier.hh"
+
+namespace node_webrtc {
+
+PacketSocketFactoryWithTlsCertVerifier::PacketSocketFactoryWithTlsCertVerifier(
+    std::unique_ptr<webrtc::PacketSocketFactory> inner)
+    : inner_(std::move(inner)),
+      tls_cert_verifier_(CreateWindowsPlatformCertificateVerifier()) {}
+
+PacketSocketFactoryWithTlsCertVerifier::~PacketSocketFactoryWithTlsCertVerifier() =
+    default;
+
+std::unique_ptr<webrtc::AsyncPacketSocket>
+PacketSocketFactoryWithTlsCertVerifier::CreateUdpSocket(
+    const webrtc::Environment& env,
+    const webrtc::SocketAddress& address,
+    uint16_t min_port,
+    uint16_t max_port) {
+  return inner_->CreateUdpSocket(env, address, min_port, max_port);
+}
+
+std::unique_ptr<webrtc::AsyncListenSocket>
+PacketSocketFactoryWithTlsCertVerifier::CreateServerTcpSocket(
+    const webrtc::Environment& env,
+    const webrtc::SocketAddress& local_address,
+    uint16_t min_port,
+    uint16_t max_port,
+    int opts) {
+  return inner_->CreateServerTcpSocket(env, local_address, min_port, max_port,
+                                       opts);
+}
+
+std::unique_ptr<webrtc::AsyncPacketSocket>
+PacketSocketFactoryWithTlsCertVerifier::CreateClientTcpSocket(
+    const webrtc::Environment& env,
+    const webrtc::SocketAddress& local_address,
+    const webrtc::SocketAddress& remote_address,
+    const webrtc::PacketSocketTcpOptions& tcp_options) {
+  return inner_->CreateClientTcpSocket(env, local_address, remote_address,
+                                       WithTlsVerifier(tcp_options));
+}
+
+std::unique_ptr<webrtc::AsyncDnsResolverInterface>
+PacketSocketFactoryWithTlsCertVerifier::CreateAsyncDnsResolver() {
+  return inner_->CreateAsyncDnsResolver();
+}
+
+std::unique_ptr<webrtc::AsyncPacketSocket>
+PacketSocketFactoryWithTlsCertVerifier::CreateClientUdpSocket(
+    const webrtc::Environment& env,
+    const webrtc::SocketAddress& local_address,
+    const webrtc::SocketAddress& remote_address,
+    uint16_t min_port,
+    uint16_t max_port,
+    const webrtc::PacketSocketTcpOptions& options) {
+  return inner_->CreateClientUdpSocket(env, local_address, remote_address,
+                                       min_port, max_port,
+                                       WithTlsVerifier(options));
+}
+
+webrtc::PacketSocketTcpOptions
+PacketSocketFactoryWithTlsCertVerifier::WithTlsVerifier(
+    const webrtc::PacketSocketTcpOptions& options) const {
+  auto wrapped = options;
+
+#if defined(WEBRTC_WIN)
+  const bool wants_secure_tls =
+      (options.opts & webrtc::PacketSocketFactory::OPT_TLS) != 0;
+  if (wants_secure_tls && wrapped.tls_cert_verifier == nullptr &&
+      tls_cert_verifier_ != nullptr) {
+    RTC_LOG(LS_INFO)
+        << "PacketSocketFactoryWithTlsCertVerifier: injecting Windows TLS "
+           "certificate verifier";
+    wrapped.tls_cert_verifier = tls_cert_verifier_.get();
+  }
+#endif
+
+  return wrapped;
+}
+
+}  // namespace node_webrtc

--- a/src/webrtc/packet_socket_factory_with_tls_cert_verifier.hh
+++ b/src/webrtc/packet_socket_factory_with_tls_cert_verifier.hh
@@ -1,0 +1,57 @@
+/* Copyright (c) 2026 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#pragma once
+
+#include <memory>
+
+#include <webrtc/api/packet_socket_factory.h>
+
+namespace node_webrtc {
+
+class PacketSocketFactoryWithTlsCertVerifier final
+    : public webrtc::PacketSocketFactory {
+ public:
+  explicit PacketSocketFactoryWithTlsCertVerifier(
+      std::unique_ptr<webrtc::PacketSocketFactory> inner);
+  ~PacketSocketFactoryWithTlsCertVerifier() override;
+
+  std::unique_ptr<webrtc::AsyncPacketSocket> CreateUdpSocket(
+      const webrtc::Environment& env,
+      const webrtc::SocketAddress& address,
+      uint16_t min_port,
+      uint16_t max_port) override;
+  std::unique_ptr<webrtc::AsyncListenSocket> CreateServerTcpSocket(
+      const webrtc::Environment& env,
+      const webrtc::SocketAddress& local_address,
+      uint16_t min_port,
+      uint16_t max_port,
+      int opts) override;
+  std::unique_ptr<webrtc::AsyncPacketSocket> CreateClientTcpSocket(
+      const webrtc::Environment& env,
+      const webrtc::SocketAddress& local_address,
+      const webrtc::SocketAddress& remote_address,
+      const webrtc::PacketSocketTcpOptions& tcp_options) override;
+  std::unique_ptr<webrtc::AsyncDnsResolverInterface> CreateAsyncDnsResolver()
+      override;
+  std::unique_ptr<webrtc::AsyncPacketSocket> CreateClientUdpSocket(
+      const webrtc::Environment& env,
+      const webrtc::SocketAddress& local_address,
+      const webrtc::SocketAddress& remote_address,
+      uint16_t min_port,
+      uint16_t max_port,
+      const webrtc::PacketSocketTcpOptions& options) override;
+
+ private:
+  webrtc::PacketSocketTcpOptions WithTlsVerifier(
+      const webrtc::PacketSocketTcpOptions& options) const;
+
+  std::unique_ptr<webrtc::PacketSocketFactory> inner_;
+  std::unique_ptr<webrtc::SSLCertificateVerifier> tls_cert_verifier_;
+};
+
+}  // namespace node_webrtc

--- a/src/webrtc/windows_platform_certificate_verifier.cc
+++ b/src/webrtc/windows_platform_certificate_verifier.cc
@@ -1,0 +1,195 @@
+/* Copyright (c) 2026 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#include "src/webrtc/windows_platform_certificate_verifier.hh"
+
+#if defined(WEBRTC_WIN)
+
+#include <windows.h>
+#include <wincrypt.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <webrtc/rtc_base/buffer.h>
+#include <webrtc/rtc_base/logging.h>
+
+namespace node_webrtc {
+namespace {
+
+struct CertContextDeleter {
+  void operator()(const CERT_CONTEXT* cert) const {
+    if (cert != nullptr) {
+      CertFreeCertificateContext(cert);
+    }
+  }
+};
+
+struct CertStoreDeleter {
+  void operator()(const void* store) const {
+    if (store != nullptr) {
+      CertCloseStore(static_cast<HCERTSTORE>(const_cast<void*>(store)), 0);
+    }
+  }
+};
+
+struct CertChainContextDeleter {
+  void operator()(const CERT_CHAIN_CONTEXT* chain) const {
+    if (chain != nullptr) {
+      CertFreeCertificateChain(chain);
+    }
+  }
+};
+
+using UniqueCertContext =
+    std::unique_ptr<const CERT_CONTEXT, CertContextDeleter>;
+using UniqueCertStore = std::unique_ptr<const void, CertStoreDeleter>;
+using UniqueCertChainContext =
+    std::unique_ptr<const CERT_CHAIN_CONTEXT, CertChainContextDeleter>;
+
+UniqueCertContext CreateCertificateContext(
+    const webrtc::SSLCertificate& certificate) {
+  webrtc::Buffer der;
+  certificate.ToDER(&der);
+  if (der.empty()) {
+    RTC_LOG(LS_WARNING)
+        << "WindowsPlatformCertificateVerifier: empty DER certificate";
+    return UniqueCertContext(nullptr);
+  }
+
+  return UniqueCertContext(CertCreateCertificateContext(
+      X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+      reinterpret_cast<const BYTE*>(der.data()),
+      static_cast<DWORD>(der.size())));
+}
+
+class WindowsPlatformCertificateVerifier final
+    : public webrtc::SSLCertificateVerifier {
+ public:
+  bool VerifyChain(const webrtc::SSLCertChain& chain) override {
+    if (chain.GetSize() == 0) {
+      RTC_LOG(LS_WARNING)
+          << "WindowsPlatformCertificateVerifier: empty certificate chain";
+      return false;
+    }
+
+    UniqueCertContext leaf_context(CreateCertificateContext(chain.Get(0)));
+    if (!leaf_context) {
+      RTC_LOG(LS_WARNING)
+          << "WindowsPlatformCertificateVerifier: failed to create leaf "
+             "certificate context, error="
+          << GetLastError();
+      return false;
+    }
+
+    UniqueCertStore intermediate_store(
+        CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0,
+                      CERT_STORE_CREATE_NEW_FLAG, nullptr));
+    if (!intermediate_store) {
+      RTC_LOG(LS_WARNING)
+          << "WindowsPlatformCertificateVerifier: failed to create "
+             "intermediate store, error="
+          << GetLastError();
+      return false;
+    }
+
+    for (size_t i = 1; i < chain.GetSize(); ++i) {
+      UniqueCertContext cert_context(CreateCertificateContext(chain.Get(i)));
+      if (!cert_context) {
+        RTC_LOG(LS_WARNING)
+            << "WindowsPlatformCertificateVerifier: failed to create "
+               "intermediate certificate context at index "
+            << i << ", error=" << GetLastError();
+        return false;
+      }
+
+      if (!CertAddCertificateContextToStore(
+              static_cast<HCERTSTORE>(const_cast<void*>(intermediate_store.get())),
+              cert_context.get(), CERT_STORE_ADD_ALWAYS, nullptr)) {
+        RTC_LOG(LS_WARNING)
+            << "WindowsPlatformCertificateVerifier: failed to add "
+               "intermediate certificate to store at index "
+            << i << ", error=" << GetLastError();
+        return false;
+      }
+    }
+
+    LPCSTR usage_identifiers[] = {szOID_PKIX_KP_SERVER_AUTH};
+    CERT_CHAIN_PARA chain_parameters = {};
+    chain_parameters.cbSize = sizeof(chain_parameters);
+    chain_parameters.RequestedUsage.dwType = USAGE_MATCH_TYPE_OR;
+    chain_parameters.RequestedUsage.Usage.cUsageIdentifier = 1;
+    chain_parameters.RequestedUsage.Usage.rgpszUsageIdentifier =
+        const_cast<LPSTR*>(usage_identifiers);
+
+    PCCERT_CHAIN_CONTEXT raw_chain_context = nullptr;
+    if (!CertGetCertificateChain(
+            nullptr, leaf_context.get(), nullptr,
+            static_cast<HCERTSTORE>(const_cast<void*>(intermediate_store.get())),
+            &chain_parameters, 0, nullptr, &raw_chain_context)) {
+      RTC_LOG(LS_WARNING)
+          << "WindowsPlatformCertificateVerifier: CertGetCertificateChain "
+             "failed, error="
+          << GetLastError();
+      return false;
+    }
+
+    UniqueCertChainContext chain_context(raw_chain_context);
+
+    CERT_CHAIN_POLICY_PARA policy_parameters = {};
+    policy_parameters.cbSize = sizeof(policy_parameters);
+
+    CERT_CHAIN_POLICY_STATUS policy_status = {};
+    policy_status.cbSize = sizeof(policy_status);
+
+    if (!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_BASE,
+                                          chain_context.get(),
+                                          &policy_parameters,
+                                          &policy_status)) {
+      RTC_LOG(LS_WARNING)
+          << "WindowsPlatformCertificateVerifier: "
+             "CertVerifyCertificateChainPolicy failed, error="
+          << GetLastError();
+      return false;
+    }
+
+    if (policy_status.dwError != 0) {
+      RTC_LOG(LS_WARNING)
+          << "WindowsPlatformCertificateVerifier: certificate chain rejected, "
+             "policy_error="
+          << policy_status.dwError;
+      return false;
+    }
+
+    RTC_LOG(LS_INFO)
+        << "WindowsPlatformCertificateVerifier: platform trust validation ok";
+    return true;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<webrtc::SSLCertificateVerifier>
+CreateWindowsPlatformCertificateVerifier() {
+  return std::make_unique<WindowsPlatformCertificateVerifier>();
+}
+
+}  // namespace node_webrtc
+
+#else
+
+namespace node_webrtc {
+
+std::unique_ptr<webrtc::SSLCertificateVerifier>
+CreateWindowsPlatformCertificateVerifier() {
+  return nullptr;
+}
+
+}  // namespace node_webrtc
+
+#endif

--- a/src/webrtc/windows_platform_certificate_verifier.hh
+++ b/src/webrtc/windows_platform_certificate_verifier.hh
@@ -1,0 +1,19 @@
+/* Copyright (c) 2026 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#pragma once
+
+#include <memory>
+
+#include <webrtc/rtc_base/ssl_certificate.h>
+
+namespace node_webrtc {
+
+std::unique_ptr<webrtc::SSLCertificateVerifier>
+CreateWindowsPlatformCertificateVerifier();
+
+}  // namespace node_webrtc

--- a/src/webrtc_compat.hh
+++ b/src/webrtc_compat.hh
@@ -1,0 +1,7 @@
+#pragma once
+
+// libwebrtc main moved large parts of the former rtc::* API surface into the
+// webrtc namespace. Keep the existing addon sources compiling while we port the
+// remaining API deltas incrementally.
+namespace webrtc {}
+namespace rtc = webrtc;


### PR DESCRIPTION
## What changed

This PR ports the addon forward to a newer libwebrtc baseline and adds a Windows platform certificate verifier for secure TURN/TLS connections.

Key pieces:

- adds a Windows CryptoAPI-backed `SSLCertificateVerifier`
- injects that verifier for secure TLS sockets used by the packet socket factory
- keeps plain TURN/TCP behavior unchanged
- includes the compatibility and build-system updates needed to build against a newer libwebrtc tree
- preserves native logging hooks used to diagnose TURN/TLS failures

## Why

The failing TURN-over-TLS path reproduced as:

- TCP connect succeeded
- TLS started
- BoringSSL verification failed with `unable to get local issuer certificate`
- TURN never sent ALLOCATE

On the same machine and credentials, plain `turn:3478` succeeded, including the `401` challenge and subsequent successful ALLOCATE.

That showed the breakage was in the native TLS validation path, not TURN auth.

This change lets the Windows addon validate TURN/TLS chains against the platform trust store instead of failing in the built-in verification path.

## Validation

- built `wrtc.node` successfully on Windows against the newer libwebrtc tree
- reran the TURN harness with native logs enabled
- confirmed `turns:443` now completes TLS, sends ALLOCATE, and gathers a relay candidate
- confirmed `turn:3478` still succeeds
