### PR TITLE
Add prebuilt-binary for armv7l

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ still be able to [build from source](docs/build-from-source.md).
   <thead>
     <tr>
       <td colspan="2" rowspan="2"></td>
-      <th colspan="2">Linux</th>
+      <th colspan="3">Linux</th>
       <th colspan="2">macOS</th>
       <th>Windows</th>
     </tr>
     <tr>
       <th>x64</th>
       <th>arm64</th>
+      <th>arm</th>
       <th>x64</th>
       <th>arm64</th>
       <th>x64</th>
@@ -57,11 +58,13 @@ still be able to [build from source](docs/build-from-source.md).
       <td align="center">✓</td>
       <td align="center">✓</td>
       <td align="center">✓</td>
+      <td align="center">✓</td>
     </tr>
     <tr>
       <th>22</th>
       <td align="center">✓</td>
       <td align="center">?</td>
+      <td align="center">✓</td>
       <td align="center">✓</td>
       <td align="center">✓</td>
       <td align="center">✓</td>

--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -50,10 +50,11 @@ The supported cross-compilation directions are:
 - MacOS arm64 ➡️ MacOS x64
 - MacOS x64 ➡️ ️MacOS arm64
 - Linux x64 ➡️ Linux arm64
+- Linux x64 ➡️ Linux arm (32-bit, e.g. Raspberry Pi 3B+)
 
 To run e.g. that that cross-compilation:
 
-1. Set `TARGET_ARCH` to "arm64"
+1. Set `TARGET_ARCH` to "arm64" (or "arm" for 32-bit ARM)
 2. Re-run `npm run build`
 
 ### Debug Builds

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "optionalDependencies": {
     "@roamhq/wrtc-darwin-arm64": "0.10.0",
     "@roamhq/wrtc-darwin-x64": "0.10.0",
+    "@roamhq/wrtc-linux-arm": "0.10.0",
     "@roamhq/wrtc-linux-arm64": "0.10.0",
     "@roamhq/wrtc-linux-x64": "0.10.0",
     "@roamhq/wrtc-win32-x64": "0.10.0",

--- a/prebuilds/linux-arm/README.md
+++ b/prebuilds/linux-arm/README.md
@@ -1,0 +1,4 @@
+# wrtc
+
+This is the Linux 32-bit ARM binary build for @roamhq/wrtc.
+See https://github.com/WonderInventions/node-webrtc for details.

--- a/prebuilds/linux-arm/index.js
+++ b/prebuilds/linux-arm/index.js
@@ -1,0 +1,2 @@
+"use strict";
+module.exports = require("./wrtc.node");

--- a/prebuilds/linux-arm/package.json
+++ b/prebuilds/linux-arm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@roamhq/wrtc-linux-arm",
+  "version": "0.10.0",
+  "description": "The Linux 32-bit ARM binary for @roamhq/wrtc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WonderInventions/node-webrtc.git"
+  },
+  "license": "BSD-2-Clause",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm"
+  ]
+}

--- a/shell.nix
+++ b/shell.nix
@@ -23,8 +23,11 @@ let
         nativeBuildInputs =
           (with pkgs; [
             cmake
+            curl
+            git
             ninja
             nodejs_22
+            perl
             pkg-config
             zlib
             # For stripping binaries for release
@@ -41,6 +44,7 @@ let
           ])
           ++ (lib.optionals (!is-darwin) [
             (llvm pkgs.pkgsCross.aarch64-multiplatform.buildPackages).clang
+            (llvm pkgs.pkgsCross.armv7l-hf-multiplatform.buildPackages).clang
           ]);
         # Build variables based on documentation from https://github.com/timniederhausen/gn-build/blob/01c96fd9981b111a3a028356284968acd77fa435/README.md
         shellHook =

--- a/toolchains/linux-arm.toolchain
+++ b/toolchains/linux-arm.toolchain
@@ -1,0 +1,5 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_C_COMPILER armv7l-unknown-linux-gnueabihf-clang)
+set(CMAKE_CXX_COMPILER armv7l-unknown-linux-gnueabihf-clang++)


### PR DESCRIPTION
### Description

Thank you for reviving this project. We noticed that the prebuilt binary for armv7l (32 bit), which used to be available is now missing. It would be great if this can be added back, as we would like to still use it for our Raspberry PI 3b+ deployment. The PI in question are still running with Raspberry PI OS Bookworm 32 bit. Upgrade to 64 bit OS is planned, but are very tricky and problematic to do cleanly across fleet.

We would be happy to be assigned as the maintainer and tester of the armv7l build.

This was made with assistance from Claude, build confirmed to be completed successfully and validated in a smoke test via QEMU. We've also tested this running correctly in a Raspberry PI 3b+ Running Bookworm 32 bit.

### Test

I also tried to run `test/all.js` with the prebuilt binary through QEmu, and all test were successful, except the 3 in `custom-settings.js`.. according to Claude, this is because `SimplePeer` provided the following default `iceServers`, and a `stun` server with `?transport` is invalid.. and it claim the same test would fail also with the other M114 build..

```
iceServers: [
  { urls: 'stun:stun.l.google.com:19302' },
  { urls: 'stun:global.stun.twilio.com:3478?transport=udp' }
]
```

NOTE: I also noticed that there's already a PR (https://github.com/WonderInventions/node-webrtc/pull/49) for fixing the build/test in M114. I'll rebase this branch once the other PR is merged. locally `test/all.js` passed with the arm prebuilt binary post-rebase.

### Additional smoke test

```sh
cd /home/ignatiusreza/Work/repo/node-webrtc
export QEMU=/nix/store/ljrgkqh0myarydz1arxzaqy32wlf08mf-qemu-11.0.1/bin/qemu-arm
export ARMSYSROOT=/nix/store/1kc9bq82z4m6i250gs9ap324yrxnxb86-glibc-armv7l-unknown-linux-gnueabihf-2.40-66
export GCCLIB=/nix/store/phbybsb7jijyr0pllwhqmhmmlnan15ci-armv7l-unknown-linux-gnueabihf-gcc-14.3.0-lib/armv7l-unknown-linux-gnueabihf/lib
NODE_BIN=/tmp/armtest/node-v20.18.0-linux-armv7l/bin/node
timeout 60 "$QEMU" -L "$ARMSYSROOT" -E LD_LIBRARY_PATH="$GCCLIB" "$NODE_BIN" --expose-gc arm-smoke-test.js 2>&1
```

> dc1 open, sending message
> pc2 received: hello from pc1
> ALL GOOD - full connection established

```js
// arm-smoke-test.js
const wrtc = require("./lib/index.js");

const pc1 = new wrtc.RTCPeerConnection();
const pc2 = new wrtc.RTCPeerConnection();

pc1.onicecandidate = (e) => {
  if (e.candidate) pc2.addIceCandidate(e.candidate);
};
pc2.onicecandidate = (e) => {
  if (e.candidate) pc1.addIceCandidate(e.candidate);
};

const dc1 = pc1.createDataChannel("test");
dc1.onopen = () => {
  console.log("dc1 open, sending message");
  dc1.send("hello from pc1");
};

pc2.ondatachannel = (e) => {
  const dc2 = e.channel;
  dc2.onmessage = (msg) => {
    console.log("pc2 received:", msg.data);
    console.log("ALL GOOD - full connection established");
    process.exit(0);
  };
};

setTimeout(() => {
  console.log("TIMEOUT - connection did not establish");
  process.exit(1);
}, 20000);

pc1.createOffer()
  .then((offer) => pc1.setLocalDescription(offer))
  .then(() => pc2.setRemoteDescription(pc1.localDescription))
  .then(() => pc2.createAnswer())
  .then((answer) => pc2.setLocalDescription(answer))
  .then(() => pc1.setRemoteDescription(pc2.localDescription))
  .catch((e) => {
    console.log("FAILED", e);
    process.exit(1);
  });
```