### PR TITLE
fix(RefPtr): avoid use-after-free at environment exit by holding an owned napi reference

### DIFF
--- a/src/node/ref_ptr.hh
+++ b/src/node/ref_ptr.hh
@@ -8,93 +8,110 @@
 #pragma once
 
 #include <cstddef>
+#include <napi.h>
+
 namespace node_webrtc {
 
 /**
  * A class that provides strong ownership of a Napi::ObjectWrap pointer.
  *
- * The underlying value is `Ref()`ed when this is created, and `Unref()`ed when
- * this is destroyed.
+ * The RefPtr keeps the wrapped JavaScript object alive through its *own*
+ * persistent reference (`napi_create_reference`) rather than by calling
+ * `Ref()`/`Unref()` on the ObjectWrap it points at.
+ *
+ * When the Node.js environment shuts down, remaining wrappers are finalized in
+ * an unspecified order (most recently created first in practice). If this
+ * destructor ran after the pointee's wrapper had already been deleted, calling
+ * `_ptr->Unref()` would dereference freed memory: `~RTCRtpReceiver` unref'ing a
+ * `MediaStreamTrack` wrapper that Node had just finalized crashed with SIGSEGV
+ * in `napi_reference_unref`. A reference we own ourselves is userland-owned,
+ * survives environment finalization, and deleting it is always valid.
  *
  * We don't provide a `WeakRefPtr` class, because that is effectively just
  * a regular pointer type.
  */
 template <typename T> class RefPtr {
 public:
-  explicit RefPtr(T *ptr) : _ptr(ptr) {
-    if (_ptr) {
-      _ptr->Ref();
-    }
-  }
+  explicit RefPtr(T *ptr) : _ptr(ptr) { acquire(); }
   // NOTE(jack): I'd like it to be impossible to make an invalid one of these.
   // Unfortunately, due to Reasons, we must provide a default constructor.
   RefPtr() : _ptr(nullptr) {}
   // ... and a nullptr_t constructor
   RefPtr(std::nullptr_t) : _ptr(nullptr) {}
 
+  ~RefPtr() { release(); }
+
   // Allow assignment from a raw pointer, as an alternate copy constructor
   RefPtr &operator=(T *ptr) {
     if (_ptr == ptr) {
       return *this;
     }
-
-    if (_ptr) {
-      _ptr->Unref();
-    }
+    release();
     _ptr = ptr;
-    if (_ptr) {
-      _ptr->Ref();
-    }
+    acquire();
     return *this;
   }
+
   // Allow implicit and explicit conversion to a raw pointer
   operator T *() const { return _ptr; }
   T *ptr() const { return _ptr; }
 
   // Allow access to inner fields thru the pointer
   T *operator->() { return _ptr; }
-  ~RefPtr() {
-    if (_ptr) {
-      _ptr->Unref();
-    }
-  }
 
-  // Copy constructor: add another ref
-  RefPtr(const RefPtr &other) : _ptr(other._ptr) {
-    if (_ptr) {
-      _ptr->Ref();
-    }
-  }
+  // Copy constructor: take another reference of our own
+  RefPtr(const RefPtr &other) : _ptr(other._ptr) { acquire(); }
   RefPtr &operator=(const RefPtr &other) {
     if (this == &other) {
       return *this;
     }
-
-    if (_ptr) {
-      _ptr->Unref();
-    }
+    release();
     _ptr = other._ptr;
-    if (_ptr) {
-      _ptr->Ref();
-    }
+    acquire();
     return *this;
   }
 
-  // Move constructor: set other's _ptr to nullptr in order to transfer
-  // ownership
-  RefPtr(RefPtr &&other) noexcept : _ptr(other._ptr) { other._ptr = nullptr; }
-  RefPtr &operator=(RefPtr &&other) noexcept {
-    if (_ptr) {
-      _ptr->Unref();
-    }
-    _ptr = other._ptr;
+  // Move constructor: transfer the pointer and the reference we already hold
+  RefPtr(RefPtr &&other) noexcept
+      : _ptr(other._ptr), _ref(std::move(other._ref)) {
     other._ptr = nullptr;
-    // We keep the `->Ref()` call that other._ptr already made
+  }
+  RefPtr &operator=(RefPtr &&other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+    release();
+    _ptr = other._ptr;
+    _ref = std::move(other._ref);
+    other._ptr = nullptr;
     return *this;
   }
 
 private:
+  void acquire() {
+    if (!_ptr) {
+      return;
+    }
+    // ObjectWrap<T> is a Reference<Object> to its own JavaScript object. If
+    // that object is already unreachable (collected, finalizer pending) there
+    // is nothing left to pin; keep the raw pointer, as before, but hold no
+    // reference of our own.
+    Napi::Object value = _ptr->Value();
+    if (value.IsEmpty()) {
+      return;
+    }
+    _ref = Napi::Persistent(value);
+  }
+
+  void release() {
+    // Never touches `*_ptr`: safe even if the pointee's wrapper was already
+    // finalized by the environment shutdown.
+    _ref.Reset();
+    _ptr = nullptr;
+  }
+
   T *_ptr;
+  Napi::ObjectReference _ref;
 };
 
 } // namespace node_webrtc


### PR DESCRIPTION
## Problem

At Node.js environment exit, remaining `ObjectWrap` instances are finalized in an unspecified order — in practice most-recently-created first (`napi_env__::DeleteMe` → `RefTracker::FinalizeAll`, head-first, and `Link` pushes at the head). `RefPtr<T>::~RefPtr` calls `_ptr->Unref()` on the pointee. When a `MediaStreamTrack` wrapper is finalized before the `RTCRtpReceiver` that owns it through `OwnedWrap<MediaStreamTrack> _track_wrap`, the receiver's destructor dereferences freed memory and the process dies with **SIGSEGV in `napi_reference_unref`**.

Observed in production (Node 24.19.0, `@roamhq/wrtc` 0.10.0 linux-x64) whenever a peer/transceiver/receiver/track tuple is still alive at natural process exit — no offer/answer or media traffic needed. Core backtrace:

```
#0 napi_reference_unref
#1 node_webrtc::RefPtr<node_webrtc::MediaStreamTrack>::~RefPtr
#2 (owned track map destruction)
#3 node_webrtc::RTCRtpReceiver::~RTCRtpReceiver
#4 Napi::ObjectWrap finalization
#5 node_napi_env__::DeleteMe / Environment cleanup
```

The Node docs for [finalization on the exit of the environment](https://github.com/nodejs/node/blob/v24.19.0/doc/api/n-api.md#finalization-on-the-exit-of-the-nodejs-environment) state that finalizers run without guaranteed dependency order. This is distinct from #7 (`AsyncContextReleaser`, fixed in 0.9.0).

## Fix

`RefPtr` now pins the pointee's JavaScript object with its **own** persistent reference (`Napi::Persistent`, i.e. `napi_create_reference` with count 1) and just resets that reference in its destructor. It never calls `Ref()`/`Unref()` on the pointee's wrapper, so it does not matter whether that wrapper has already been deleted. Userland references survive environment finalization (`Reference::Finalize` only deletes `ReferenceOwnership::kRuntime` references) and `napi_delete_reference` simply deletes the caller's own object, so the destructor is valid in every order.

Semantics are unchanged: a held object survives GC, and becomes collectable as soon as the last `RefPtr` releases it or its owner is collected. Move/copy transfer or duplicate the owned reference as before. The only cost is `sizeof(RefPtr)` growing from one pointer to pointer + `Napi::ObjectReference`.

## Verification

Minimal two-wrapper N-API addon (no WebRTC): `Owner` holds `Target` through `RefPtr<Target>`; the tuple is retained until exit. Built with `-DNAPI_VERSION=3`, node-addon-api 7.1.1, `-fsanitize=address`, run under ASan in three construction orders (`target-first`, `owner-first`, `released`) plus two GC-semantics runs (`release`, `orphan`) with `--expose-gc`:

| Platform | unpatched `owner-first` | patched (all 5 runs) |
|---|---|---|
| Linux x64, gcc 13.3, Node 24.19.0 | `heap-use-after-free` in `Napi::Reference<Napi::Object>::Unref()` | clean, exit 0 |
| Linux arm64, gcc 12, Node 24.20.0 | same | clean, exit 0 |
| macOS arm64, clang 17, Node 24.3.0 | same (`RefPtr<Target>::~RefPtr ref_ptr.hh:58`) | clean, exit 0 |

GC runs on both versions produce the identical sequence: held target survives four forced GCs; `target_finalized` appears right after `release()` / after the owner is collected.

Happy to add the reference addon under `test/` if you'd like it in-tree; it is ~40 lines of C++ and a 20-line driver.
